### PR TITLE
docs: clarify held-out gate semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Zetta is an efficient closed-loop embodied harness for self-evolving physical in
   -> Shadow Replay
   -> paired Same-seed Gate
   -> Held-out seeds 1..20
-  -> Reject and return to Stage 2, or Promote and complete
+     -> validation mode: Reject (refine if budget remains), or Promote
+     -> test mode: Record an unbiased final report without feeding selection
 ```
 
 Runtime role boundaries:
@@ -156,6 +157,9 @@ python scripts/evolution/prepare_libero_campaign.py \
   --heldout-mode test \
   --runtime-url http://127.0.0.1:18730 \
   --runtime-policy-id <policy-id>
+
+# `--heldout-mode test` keeps the fixed block report-only. To make a held-out
+# failure reject the candidate, preregister `--heldout-mode validation` instead.
 
 # 2. Run it: this starts the worker, ingests episodes, and drives
 #    Cluster -> Diagnose -> Stage2 -> Shadow Replay -> Same-seed -> Held-out.

--- a/tests/test_evolution_protocol.py
+++ b/tests/test_evolution_protocol.py
@@ -181,6 +181,8 @@ def test_validation_heldout_failure_obeys_round_limit(tmp_path: Path) -> None:
     assert store.state()["optimization_outcome"] == (
         "heldout_validation_iteration_budget_exhausted"
     )
+    with pytest.raises(ValueError, match="promotion requires promote phase"):
+        store.promote(candidate.sha256)
 
 
 def test_same_seed_failure_obeys_explicit_round_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- distinguish report-only `heldout_mode=test` from promotion-gating `heldout_mode=validation` in the evolution protocol
- clarify the mode used by the runnable LIBERO campaign example
- assert that a failed held-out validation cannot enter promotion

## Why

The README example preregisters `--heldout-mode test`, while the protocol diagram previously implied that every held-out failure rejects a candidate. The lifecycle intentionally treats test mode as an unbiased report-only measurement and validation mode as the formal promotion gate.

## Test plan

```bash
python -m pytest -q \
  tests/test_evolution_protocol.py \
  tests/test_evolution_core.py \
  tests/test_libero_eval_horizon.py
```

Result: `29 passed` (no simulator or model required).