### PR TITLE
feat(cosmos): add Cosmos-Lite policy backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ ray = [
 openpi = [
     "rlinf-openpi",
 ]
+cosmos-lite = [
+    "websockets>=11,<17",
+]
 libero = []
 # Simulator distributions are intentionally not declared here: liberopro and
 # liberoplus publish transitive dependencies on the main RLinf framework. The
@@ -75,7 +78,7 @@ libero = []
 libero-pro = []
 libero-plus = []
 full = [
-    "zetta[ray,openpi,libero-pro,sam3]",
+    "zetta[ray,openpi,libero-pro,sam3,cosmos-lite]",
 ]
 sam3 = [
     "sam3==0.1.4",

--- a/rollout_runtime/backends/__init__.py
+++ b/rollout_runtime/backends/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Zetta Contributors
 """Env and policy backends, plus the sole resolution point for "select a backend by config."
 
 ``fake`` is pure stdlib + numpy; ``rlinf_env`` / ``rlinf_policy`` and
@@ -54,9 +55,8 @@ image, so it remains "declared but not implemented," and
 ``RoboCasaSession``) will be added later.
 """
 
-POLICY_BACKENDS = ("fake", "zetta_openpi", "groot")
-"""Optional policy backends: ``fake``, ``zetta_openpi`` (openpi / pi0.5), and
-``groot`` (the current branch's GR00T)."""
+POLICY_BACKENDS = ("fake", "zetta_openpi", "groot", "cosmos_lite")
+"""Optional policy backends, including remote Cosmos-Lite serving."""
 
 
 def register_env_family_for(env_family: str) -> Any:
@@ -116,7 +116,8 @@ def build_policy_core(
     """Build a ``PolicyInferenceCore`` for the named backend.
 
     Args:
-        backend: ``"fake"``, ``"rlinf"``, or ``"groot"``.
+        backend: ``"fake"``, ``"zetta_openpi"``, ``"groot"``, or
+            ``"cosmos_lite"``.
         policy_config: Backend-private configuration (``RlinfPolicyConfig``
             fields for the ``rlinf`` backend, ``GrootPolicyConfig`` fields
             for the ``groot`` backend).
@@ -178,6 +179,22 @@ def build_policy_core(
         if model_version:
             merged.setdefault("model_version", model_version)
         return GrootPolicyCore(GrootPolicyConfig.from_mapping(merged))
+    if backend == "cosmos_lite":
+        from rollout_runtime.backends.cosmos_lite import (
+            CosmosLitePolicyConfig,
+            CosmosLitePolicyCore,
+        )
+
+        merged = dict(policy_config or {})
+        merged.setdefault("device", device)
+        merged.setdefault("dtype", dtype)
+        merged.setdefault("action_dim", action_dim)
+        merged.setdefault("actions_per_chunk", actions_per_chunk)
+        if model_version:
+            raise ValueError(
+                "cosmos_lite model_version is derived from its verified deployment"
+            )
+        return CosmosLitePolicyCore(CosmosLitePolicyConfig.from_mapping(merged))
     raise ValueError(
         f"unknown policy backend {backend!r}; expected one of {list(POLICY_BACKENDS)}"
     )
@@ -194,7 +211,8 @@ def policy_compat_constraints(
     so this function copies them over to the EnvWorker.
 
     Args:
-        backend: ``"fake"``, ``"rlinf"``, or ``"groot"``.
+        backend: ``"fake"``, ``"zetta_openpi"``, ``"groot"``, or
+            ``"cosmos_lite"``.
         policy_config: Backend-private configuration.
 
     Returns:
@@ -202,6 +220,12 @@ def policy_compat_constraints(
         (GR00T does not support cuda_graph/fixed batch; single-request
         serialized inference needs no additional hard constraints).
     """
+    if backend == "cosmos_lite":
+        from rollout_runtime.backends.cosmos_lite import CosmosLitePolicyConfig
+
+        return CosmosLitePolicyConfig.from_mapping(
+            dict(policy_config or {})
+        ).compat_key_constraints()
     if backend != "zetta_openpi":
         return {}
     from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig

--- a/rollout_runtime/backends/cosmos_lite.py
+++ b/rollout_runtime/backends/cosmos_lite.py
@@ -1,0 +1,797 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Remote Cosmos-Lite policy backend.
+
+Cosmos-Lite v0.3.0 already exposes the OpenPI WebSocket policy protocol, so
+this module deliberately contains no model code.  It validates the deployment
+record written by Cosmos-Lite, translates the Runtime's generic observation to
+the upstream RoboLab/DROID request, and converts the returned action chunk to
+an :class:`ActionResponse`.
+
+The upstream server is batch-one and serializes inference internally.  This
+backend therefore performs one request at a time and never retries a request
+after it has been sent: a disconnected response has an unknown server-side
+outcome, even though policy inference itself has no environment side effect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import ipaddress
+import json
+import re
+import threading
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+import msgpack
+import numpy as np
+
+from rollout_runtime.api.enums import ErrorCode
+from rollout_runtime.api.errors import make_error
+from rollout_runtime.api.internal import ActionResponse, InferenceRequest
+from rollout_runtime.core import payload as payload_module
+
+__all__ = [
+    "COSMOS_LITE_POLICY_FAMILY",
+    "COSMOS_LITE_V030_REVISION",
+    "CosmosLiteClient",
+    "CosmosLiteModelIdentity",
+    "CosmosLitePolicyConfig",
+    "CosmosLitePolicyCore",
+    "CosmosLiteTransport",
+]
+
+COSMOS_LITE_POLICY_FAMILY = "cosmos_lite"
+COSMOS_LITE_V030_REVISION = "2b5f5f3e8c02632f04432644ac0bf31780f554b5"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_GIT_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_IMAGE_LAYOUTS = frozenset({"single", "robolab_three_view"})
+
+
+class CosmosLiteTransport(Protocol):
+    """Small injectable boundary around the upstream WebSocket protocol."""
+
+    def connect(self) -> Mapping[str, Any]:
+        """Connect and return the server handshake metadata."""
+        ...
+
+    def infer(
+        self, observation: Mapping[str, Any], *, timeout_s: float
+    ) -> Mapping[str, Any]:
+        """Send one observation and return one decoded response."""
+        ...
+
+    def close(self) -> None:
+        """Close the connection."""
+        ...
+
+
+class _RequestValidationError(ValueError):
+    """The Runtime request cannot be represented by the upstream contract."""
+
+
+class _ResponseValidationError(RuntimeError):
+    """The upstream service returned a malformed response."""
+
+
+def _pack_numpy(value: Any) -> Any:
+    """Encode NumPy values exactly as ``openpi_client.msgpack_numpy`` does."""
+    if isinstance(value, (np.ndarray, np.generic)) and value.dtype.kind in (
+        "V",
+        "O",
+        "c",
+    ):
+        raise ValueError(f"unsupported NumPy dtype: {value.dtype}")
+    if isinstance(value, np.ndarray):
+        return {
+            b"__ndarray__": True,
+            b"data": value.tobytes(),
+            b"dtype": value.dtype.str,
+            b"shape": value.shape,
+        }
+    if isinstance(value, np.generic):
+        return {
+            b"__npgeneric__": True,
+            b"data": value.item(),
+            b"dtype": value.dtype.str,
+        }
+    raise TypeError(f"cannot encode value of type {type(value).__name__}")
+
+
+def _unpack_numpy(value: dict[Any, Any]) -> Any:
+    """Decode NumPy values encoded by ``openpi_client.msgpack_numpy``."""
+    if b"__ndarray__" in value:
+        return np.ndarray(
+            buffer=value[b"data"],
+            dtype=np.dtype(value[b"dtype"]),
+            shape=tuple(value[b"shape"]),
+        )
+    if b"__npgeneric__" in value:
+        return np.dtype(value[b"dtype"]).type(value[b"data"])
+    return value
+
+
+def _pack_message(value: Mapping[str, Any]) -> bytes:
+    return msgpack.packb(value, default=_pack_numpy, use_bin_type=True)
+
+
+def _unpack_message(value: bytes) -> Any:
+    return msgpack.unpackb(
+        value,
+        object_hook=_unpack_numpy,
+        raw=False,
+        strict_map_key=False,
+    )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CosmosLiteModelIdentity:
+    """Auditable identity extracted from a Cosmos-Lite deployment record."""
+
+    repository_revision: str
+    model_family: str
+    artifact: str
+    strategy: str | None
+    manifest_sha256: str
+    resolved_config_sha256: str
+    profile: str
+    fallback_decisions: tuple[str, ...]
+    sampling: dict[str, Any]
+    runtime: dict[str, Any]
+    runtime_probe: dict[str, Any]
+    model_version: str
+
+    def auxiliary_output(self) -> dict[str, Any]:
+        """Return a msgpack-native representation for ``ActionResponse``."""
+        return {
+            "repository_revision": self.repository_revision,
+            "model_family": self.model_family,
+            "artifact": self.artifact,
+            "strategy": self.strategy,
+            "manifest_sha256": self.manifest_sha256,
+            "resolved_config_sha256": self.resolved_config_sha256,
+            "profile": self.profile,
+            "fallback_decisions": list(self.fallback_decisions),
+            "runtime_probe": dict(self.runtime_probe),
+        }
+
+
+@dataclasses.dataclass(kw_only=True)
+class CosmosLitePolicyConfig:
+    """Configuration for the remote Cosmos-Lite policy service.
+
+    ``resolved_config_path`` points to the record generated by the upstream
+    ``action_policy_server_robolab_deploy`` entry point.  Initial support is
+    intentionally restricted to a verified quantized bundle: the upstream
+    BF16 preset follows a mutable Hugging Face revision and therefore cannot
+    satisfy this backend's fail-closed identity contract.
+    """
+
+    endpoint: str = "ws://127.0.0.1:8000"
+    resolved_config_path: str = ""
+    expected_manifest_sha256: str = ""
+    expected_repository_revision: str = COSMOS_LITE_V030_REVISION
+    action_dim: int = 8
+    actions_per_chunk: int = 32
+    joint_position_dim: int = 7
+    image_layout: str = "robolab_three_view"
+    connect_timeout_s: float = 5.0
+    request_timeout_s: float = 120.0
+    maximum_payload_bytes: int = 8 * 1024 * 1024
+    allow_insecure_remote: bool = False
+    allow_dirty_upstream: bool = False
+    allow_runtime_fallbacks: bool = False
+    device: str = "cpu"
+    dtype: str = "float32"
+
+    def __post_init__(self) -> None:
+        parsed = urlparse(self.endpoint)
+        if parsed.scheme not in ("ws", "wss") or not parsed.hostname:
+            raise ValueError("endpoint must be an absolute ws:// or wss:// URL")
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise ValueError(
+                "endpoint must not contain credentials, query, or fragment"
+            )
+        if parsed.scheme == "ws" and not self.allow_insecure_remote:
+            try:
+                loopback = ipaddress.ip_address(parsed.hostname).is_loopback
+            except ValueError:
+                loopback = parsed.hostname.lower() == "localhost"
+            if not loopback:
+                raise ValueError(
+                    "plain ws:// is restricted to loopback; use wss:// or set "
+                    "allow_insecure_remote=true behind a trusted transport"
+                )
+        if not self.resolved_config_path:
+            raise ValueError("resolved_config_path is required")
+        manifest = self.expected_manifest_sha256.lower()
+        if _SHA256_RE.fullmatch(manifest) is None:
+            raise ValueError("expected_manifest_sha256 must be 64 lowercase hex chars")
+        self.expected_manifest_sha256 = manifest
+        revision = self.expected_repository_revision.lower()
+        if _GIT_SHA_RE.fullmatch(revision) is None:
+            raise ValueError(
+                "expected_repository_revision must be a full 40-character Git SHA"
+            )
+        self.expected_repository_revision = revision
+        if self.action_dim <= 0 or self.actions_per_chunk <= 0:
+            raise ValueError("action_dim and actions_per_chunk must be positive")
+        if self.joint_position_dim <= 0:
+            raise ValueError("joint_position_dim must be positive")
+        if self.image_layout not in _IMAGE_LAYOUTS:
+            raise ValueError(
+                f"image_layout must be one of {sorted(_IMAGE_LAYOUTS)}, "
+                f"got {self.image_layout!r}"
+            )
+        if self.connect_timeout_s <= 0 or self.request_timeout_s <= 0:
+            raise ValueError("connect_timeout_s and request_timeout_s must be positive")
+        if self.maximum_payload_bytes <= 0:
+            raise ValueError("maximum_payload_bytes must be positive")
+        if self.device != "cpu":
+            raise ValueError(
+                "Cosmos-Lite is a remote backend and requires device='cpu'"
+            )
+        if self.dtype != "float32":
+            raise ValueError("Cosmos-Lite action transport requires dtype='float32'")
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any] | None) -> CosmosLitePolicyConfig:
+        """Construct from ``rollout_worker.policy_config``."""
+        payload = dict(config or {})
+        known = {field.name for field in dataclasses.fields(cls)}
+        unknown = sorted(set(payload) - known)
+        if unknown:
+            raise ValueError(f"unknown cosmos_lite policy_config keys: {unknown}")
+        return cls(**payload)
+
+    def compat_key_constraints(self) -> dict[str, Any]:
+        """Return shape and service constraints for request bucketing."""
+        return {
+            "endpoint": self.endpoint,
+            "expected_manifest_sha256": self.expected_manifest_sha256,
+            "action_dim": self.action_dim,
+            "actions_per_chunk": self.actions_per_chunk,
+            "joint_position_dim": self.joint_position_dim,
+            "image_layout": self.image_layout,
+        }
+
+
+def _as_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"resolved deployment config field {name!r} must be a map")
+    return value
+
+
+def _load_model_identity(config: CosmosLitePolicyConfig) -> CosmosLiteModelIdentity:
+    path = Path(config.resolved_config_path).expanduser()
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise ValueError(
+            f"cannot read resolved deployment config {path}: {exc}"
+        ) from exc
+    try:
+        record = json.loads(raw_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid resolved deployment config {path}: {exc}") from exc
+    root = _as_mapping(record, "root")
+    if root.get("schema_version") != 1:
+        raise ValueError(
+            f"unsupported resolved deployment schema: {root.get('schema_version')!r}"
+        )
+    repository = _as_mapping(root.get("repository"), "repository")
+    revision = str(repository.get("revision") or "").lower()
+    if revision != config.expected_repository_revision:
+        raise ValueError(
+            "Cosmos-Lite repository revision mismatch: "
+            f"expected {config.expected_repository_revision}, got {revision or '<missing>'}"
+        )
+    if repository.get("dirty") is not False and not config.allow_dirty_upstream:
+        raise ValueError(
+            "Cosmos-Lite repository must be clean for a verified deployment"
+        )
+
+    model = _as_mapping(root.get("model"), "model")
+    artifact = str(model.get("artifact") or "")
+    if artifact != "quantized_bundle":
+        raise ValueError(
+            "initial Cosmos-Lite backend requires artifact='quantized_bundle' "
+            "so model weights have an immutable manifest"
+        )
+    manifest_sha256 = str(model.get("manifest_sha256") or "").lower()
+    if manifest_sha256 != config.expected_manifest_sha256:
+        raise ValueError(
+            "Cosmos-Lite manifest mismatch: "
+            f"expected {config.expected_manifest_sha256}, "
+            f"got {manifest_sha256 or '<missing>'}"
+        )
+
+    bundle = _as_mapping(root.get("bundle"), "bundle")
+    bundle_identity = {
+        "manifest_sha256": str(bundle.get("manifest_sha256") or "").lower(),
+        "model_family": str(bundle.get("model_family") or ""),
+        "strategy": str(bundle.get("strategy") or ""),
+    }
+    model_identity = {
+        "manifest_sha256": manifest_sha256,
+        "model_family": str(model.get("model_family") or ""),
+        "strategy": str(model.get("strategy") or ""),
+    }
+    if bundle_identity != model_identity:
+        raise ValueError(
+            "Cosmos-Lite bundle identity does not match resolved model identity"
+        )
+
+    fallbacks_value = root.get("fallback_decisions", [])
+    if not isinstance(fallbacks_value, list) or not all(
+        isinstance(item, str) for item in fallbacks_value
+    ):
+        raise ValueError("resolved deployment fallback_decisions must be a string list")
+    fallbacks = tuple(fallbacks_value)
+    if fallbacks and not config.allow_runtime_fallbacks:
+        raise ValueError(
+            "Cosmos-Lite resolved deployment contains runtime fallbacks: "
+            f"{list(fallbacks)}"
+        )
+
+    effective = _as_mapping(root.get("effective"), "effective")
+    profile = str(effective.get("profile") or "")
+    model_family = str(model.get("model_family") or "")
+    strategy_value = model.get("strategy")
+    strategy = str(strategy_value) if strategy_value is not None else None
+    if not profile or not model_family or not strategy:
+        raise ValueError(
+            "resolved deployment must include profile, model_family, and strategy"
+        )
+    sampling = dict(_as_mapping(effective.get("sampling"), "effective.sampling"))
+    runtime = dict(_as_mapping(effective.get("runtime"), "effective.runtime"))
+    if sampling.get("deterministic_seed") is not True:
+        raise ValueError("Cosmos-Lite service must use deterministic_seed=true")
+    runtime_probe = dict(_as_mapping(root.get("runtime_probe"), "runtime_probe"))
+    if runtime_probe.get("cuda_available") is not True:
+        raise ValueError("Cosmos-Lite runtime_probe must report cuda_available=true")
+    capability = runtime_probe.get("compute_capability")
+    if (
+        not isinstance(capability, list)
+        or len(capability) != 2
+        or not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in capability
+        )
+    ):
+        raise ValueError(
+            "Cosmos-Lite runtime_probe.compute_capability must be two integers"
+        )
+
+    resolved_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+    stable_identity = {
+        "repository_revision": revision,
+        "model": {
+            "artifact": artifact,
+            "model_family": model_family,
+            "strategy": strategy,
+            "manifest_sha256": manifest_sha256,
+        },
+        "sampling": sampling,
+        "runtime": runtime,
+        "runtime_probe": runtime_probe,
+        "fallback_decisions": list(fallbacks),
+        "interface": {
+            "action_dim": config.action_dim,
+            "actions_per_chunk": config.actions_per_chunk,
+            "joint_position_dim": config.joint_position_dim,
+            "image_layout": config.image_layout,
+        },
+    }
+    identity_sha256 = hashlib.sha256(
+        json.dumps(
+            stable_identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    model_version = f"cosmos-lite:{model_family}:{identity_sha256[:16]}"
+    return CosmosLiteModelIdentity(
+        repository_revision=revision,
+        model_family=model_family,
+        artifact=artifact,
+        strategy=strategy,
+        manifest_sha256=manifest_sha256,
+        resolved_config_sha256=resolved_sha256,
+        profile=profile,
+        fallback_decisions=fallbacks,
+        sampling=sampling,
+        runtime=runtime,
+        runtime_probe=runtime_probe,
+        model_version=model_version,
+    )
+
+
+class CosmosLiteClient:
+    """Minimal synchronous client for Cosmos-Lite's OpenPI WebSocket server."""
+
+    def __init__(self, config: CosmosLitePolicyConfig) -> None:
+        self.config = config
+        self._connection: Any = None
+        self._metadata: dict[str, Any] = {}
+
+    def connect(self) -> Mapping[str, Any]:
+        """Open the socket and consume the OpenPI metadata frame."""
+        if self._connection is not None:
+            return dict(self._metadata)
+        try:
+            from websockets.sync.client import connect
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "Cosmos-Lite support requires the 'cosmos-lite' extra: "
+                "python -m pip install -e '.[cosmos-lite]'"
+            ) from exc
+        connection = connect(
+            self.config.endpoint,
+            compression=None,
+            max_size=self.config.maximum_payload_bytes,
+            open_timeout=self.config.connect_timeout_s,
+            close_timeout=min(self.config.connect_timeout_s, 2.0),
+        )
+        try:
+            frame = connection.recv(timeout=self.config.connect_timeout_s)
+            if isinstance(frame, str):
+                raise RuntimeError(f"Cosmos-Lite handshake failed: {frame}")
+            metadata = _unpack_message(bytes(frame))
+            if not isinstance(metadata, Mapping):
+                raise RuntimeError("Cosmos-Lite handshake metadata must be a map")
+        except BaseException:
+            connection.close()
+            raise
+        self._connection = connection
+        self._metadata = dict(metadata)
+        return dict(self._metadata)
+
+    def infer(
+        self, observation: Mapping[str, Any], *, timeout_s: float
+    ) -> Mapping[str, Any]:
+        """Send one upstream-format observation without automatic retry."""
+        if self._connection is None:
+            self.connect()
+        assert self._connection is not None
+        request = _pack_message(observation)
+        if len(request) > self.config.maximum_payload_bytes:
+            raise _RequestValidationError(
+                "Cosmos-Lite request exceeds maximum_payload_bytes: "
+                f"{len(request)} > {self.config.maximum_payload_bytes}"
+            )
+        try:
+            self._connection.send(request)
+            frame = self._connection.recv(timeout=timeout_s)
+            if isinstance(frame, str):
+                raise RuntimeError(f"Cosmos-Lite server error: {frame}")
+            response_bytes = bytes(frame)
+            if len(response_bytes) > self.config.maximum_payload_bytes:
+                raise _ResponseValidationError(
+                    "Cosmos-Lite response exceeds maximum_payload_bytes"
+                )
+            response = _unpack_message(response_bytes)
+            if not isinstance(response, Mapping):
+                raise _ResponseValidationError("Cosmos-Lite response must be a map")
+            return response
+        except BaseException:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Close the current connection, if any."""
+        connection, self._connection = self._connection, None
+        self._metadata = {}
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception:
+                pass
+
+
+class CosmosLitePolicyCore:
+    """``PolicyInferenceCore`` backed by a remote Cosmos-Lite service."""
+
+    def __init__(
+        self,
+        config: CosmosLitePolicyConfig,
+        *,
+        transport_factory: Callable[[CosmosLitePolicyConfig], CosmosLiteTransport]
+        | None = None,
+    ) -> None:
+        self.config = config
+        self._transport_factory = transport_factory or CosmosLiteClient
+        self._transport: CosmosLiteTransport | None = None
+        self._identity: CosmosLiteModelIdentity | None = None
+        self._server_metadata: dict[str, Any] = {}
+        self._lock = threading.Lock()
+        self.loaded = False
+        self.closed = False
+        self.batch_calls = 0
+        self.request_count = 0
+        self.error_count = 0
+
+    @property
+    def model_version(self) -> str:
+        """Return the verified deployment identity."""
+        if self._identity is not None:
+            return self._identity.model_version
+        return "cosmos-lite-unloaded"
+
+    @property
+    def device(self) -> str:
+        """Return the client device (the model lives in another process)."""
+        return self.config.device
+
+    @property
+    def dtype(self) -> str:
+        """Return the action transport dtype."""
+        return self.config.dtype
+
+    @property
+    def policy_family(self) -> str:
+        """Return the Runtime policy family name."""
+        return COSMOS_LITE_POLICY_FAMILY
+
+    def load(self) -> None:
+        """Verify deployment identity and connect to the upstream service."""
+        with self._lock:
+            if self.loaded:
+                return
+            if self.closed:
+                raise RuntimeError("cannot load a closed Cosmos-Lite backend")
+            identity = _load_model_identity(self.config)
+            transport = self._transport_factory(self.config)
+            try:
+                metadata = transport.connect()
+            except BaseException:
+                transport.close()
+                raise
+            self._identity = identity
+            self._transport = transport
+            self._server_metadata = dict(metadata)
+            self.loaded = True
+
+    def update_weights(self, model_version: str) -> None:
+        """Reject hot swapping; the independently served model must restart."""
+        del model_version
+        raise RuntimeError(
+            "Cosmos-Lite does not support runtime weight updates; restart the "
+            "service and the RolloutWorker with a new verified manifest"
+        )
+
+    def close(self) -> None:
+        """Close the WebSocket connection."""
+        with self._lock:
+            transport, self._transport = self._transport, None
+            if transport is not None:
+                transport.close()
+            self.loaded = False
+            self.closed = True
+
+    def infer_batch(self, requests: list[InferenceRequest]) -> list[ActionResponse]:
+        """Execute requests serially against the upstream batch-one server."""
+        if not requests:
+            return []
+        self.batch_calls += 1
+        self.request_count += len(requests)
+        return [self._infer_one(request) for request in requests]
+
+    def _infer_one(self, request: InferenceRequest) -> ActionResponse:
+        try:
+            with self._lock:
+                if not self.loaded or self._transport is None or self._identity is None:
+                    raise RuntimeError("Cosmos-Lite backend is not loaded")
+                timeout_s = self._request_timeout(request)
+                observation = self._build_observation(request)
+                packed_size = len(_pack_message(observation))
+                if packed_size > self.config.maximum_payload_bytes:
+                    raise _RequestValidationError(
+                        "Cosmos-Lite request exceeds maximum_payload_bytes: "
+                        f"{packed_size} > {self.config.maximum_payload_bytes}"
+                    )
+                response = self._transport.infer(observation, timeout_s=timeout_s)
+                actions = self._validate_response(response)
+                identity = self._identity
+        except _RequestValidationError as exc:
+            return self._error_response(request, ErrorCode.INVALID_ARGUMENT, exc)
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            return self._error_response(request, ErrorCode.DEADLINE_EXCEEDED, exc)
+        except BaseException as exc:  # noqa: BLE001 - worker boundary must be total
+            return self._error_response(request, ErrorCode.POLICY_FAILURE, exc)
+
+        timing = response.get("server_timing")
+        timing_output = (
+            {
+                str(key): float(value)
+                for key, value in timing.items()
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+            }
+            if isinstance(timing, Mapping)
+            else {}
+        )
+        return ActionResponse(
+            request_id=request.request_id,
+            session_id=request.session_id,
+            binding_token=request.binding_token,
+            episode_id=request.episode_id,
+            operation_seq=request.operation_seq,
+            actions=payload_module.encode_array(actions),
+            model_version=identity.model_version,
+            auxiliary_outputs={
+                "chunk": int(actions.shape[0]),
+                "compat_key": request.compat_key,
+                "server_timing": timing_output,
+                "server_metadata_present": bool(self._server_metadata),
+                "cosmos_lite_identity": identity.auxiliary_output(),
+            },
+        )
+
+    def _request_timeout(self, request: InferenceRequest) -> float:
+        timeout_s = self.config.request_timeout_s
+        if request.deadline is not None:
+            remaining = request.deadline - time.time()
+            if remaining <= 0:
+                raise TimeoutError("Cosmos-Lite request deadline already expired")
+            timeout_s = min(timeout_s, remaining)
+        return timeout_s
+
+    def _build_observation(self, request: InferenceRequest) -> dict[str, Any]:
+        observation = request.observation
+        instruction = (
+            request.instruction_override
+            if request.instruction_override is not None
+            else observation.instruction
+        )
+        if not isinstance(instruction, str):
+            raise _RequestValidationError("instruction must be a string")
+
+        try:
+            state = np.asarray(observation.state, dtype=np.float32)
+        except (TypeError, ValueError) as exc:
+            raise _RequestValidationError(
+                f"Cosmos-Lite state is not numeric: {exc}"
+            ) from exc
+        expected_state_dim = self.config.joint_position_dim + 1
+        if state.shape != (expected_state_dim,):
+            raise _RequestValidationError(
+                "Cosmos-Lite joint-position contract requires state shape "
+                f"({expected_state_dim},), got {state.shape}"
+            )
+        if not np.isfinite(state).all():
+            raise _RequestValidationError("Cosmos-Lite state contains NaN or Inf")
+
+        upstream: dict[str, Any] = {
+            "prompt": instruction,
+            "observation/joint_position": np.ascontiguousarray(
+                state[: self.config.joint_position_dim]
+            ),
+            "observation/gripper_position": np.ascontiguousarray(state[-1:]),
+        }
+        try:
+            if self.config.image_layout == "single":
+                if observation.main_image is None:
+                    raise _RequestValidationError(
+                        "single image_layout requires Observation.main_image"
+                    )
+                upstream["observation/image"] = payload_module.decode_image(
+                    observation.main_image
+                )
+            else:
+                if (
+                    observation.main_image is None
+                    or observation.wrist_image is None
+                    or not observation.extra_view_images
+                ):
+                    raise _RequestValidationError(
+                        "robolab_three_view requires main_image, wrist_image, "
+                        "and one extra_view_image"
+                    )
+                upstream["observation/wrist_image_left"] = payload_module.decode_image(
+                    observation.wrist_image
+                )
+                upstream["observation/exterior_image_1_left"] = (
+                    payload_module.decode_image(observation.main_image)
+                )
+                upstream["observation/exterior_image_2_left"] = (
+                    payload_module.decode_image(observation.extra_view_images[0])
+                )
+        except _RequestValidationError:
+            raise
+        except BaseException as exc:
+            raise _RequestValidationError(
+                f"cannot decode Cosmos-Lite image payload: {exc}"
+            ) from exc
+
+        self._validate_inference_parameters(request.inference_parameters)
+        return upstream
+
+    def _validate_inference_parameters(self, parameters: Mapping[str, Any]) -> None:
+        assert self._identity is not None
+        supported = {
+            "action_dim",
+            "actions_per_chunk",
+            "compute_values",
+            "guidance",
+            "mode",
+            "num_steps",
+            "seed",
+            "shift",
+        }
+        unknown = sorted(set(parameters) - supported)
+        if unknown:
+            raise _RequestValidationError(
+                f"Cosmos-Lite does not support inference parameters {unknown}"
+            )
+        if parameters.get("mode", "eval") != "eval":
+            raise _RequestValidationError("Cosmos-Lite only supports mode='eval'")
+        if bool(parameters.get("compute_values", False)):
+            raise _RequestValidationError("Cosmos-Lite does not provide value outputs")
+        shape_values = {
+            "action_dim": self.config.action_dim,
+            "actions_per_chunk": self.config.actions_per_chunk,
+        }
+        for key, expected in shape_values.items():
+            if key in parameters and parameters[key] != expected:
+                raise _RequestValidationError(
+                    f"{key} is fixed by the Cosmos-Lite service: "
+                    f"expected {expected}, got {parameters[key]!r}"
+                )
+        sampling = self._identity.sampling
+        service_values = {
+            "guidance": sampling.get("guidance"),
+            "num_steps": sampling.get("denoise_steps"),
+            "seed": sampling.get("seed"),
+            "shift": sampling.get("shift"),
+        }
+        for key, expected in service_values.items():
+            if key in parameters and parameters[key] != expected:
+                raise _RequestValidationError(
+                    f"{key} is fixed by the Cosmos-Lite service: "
+                    f"expected {expected!r}, got {parameters[key]!r}"
+                )
+
+    def _validate_response(self, response: Mapping[str, Any]) -> np.ndarray:
+        if "action" not in response:
+            raise _ResponseValidationError("Cosmos-Lite response has no 'action'")
+        try:
+            actions = np.asarray(response["action"], dtype=np.float32)
+        except (TypeError, ValueError) as exc:
+            raise _ResponseValidationError(
+                f"Cosmos-Lite action is not numeric: {exc}"
+            ) from exc
+        expected = (self.config.actions_per_chunk, self.config.action_dim)
+        if actions.shape != expected:
+            raise _ResponseValidationError(
+                f"Cosmos-Lite action shape mismatch: expected {expected}, "
+                f"got {actions.shape}"
+            )
+        if not np.isfinite(actions).all():
+            raise _ResponseValidationError("Cosmos-Lite action contains NaN or Inf")
+        return np.ascontiguousarray(actions)
+
+    def _error_response(
+        self, request: InferenceRequest, code: ErrorCode, exc: BaseException
+    ) -> ActionResponse:
+        self.error_count += 1
+        return ActionResponse(
+            request_id=request.request_id,
+            session_id=request.session_id,
+            binding_token=request.binding_token,
+            episode_id=request.episode_id,
+            operation_seq=request.operation_seq,
+            model_version=self.model_version,
+            error=make_error(
+                code,
+                f"Cosmos-Lite inference failed: {exc}",
+                policy_id=request.policy_id,
+                session_id=request.session_id,
+                endpoint=self.config.endpoint,
+            ),
+        )

--- a/rollout_runtime/config/presets/cosmos_lite_remote.yaml
+++ b/rollout_runtime/config/presets/cosmos_lite_remote.yaml
@@ -1,0 +1,79 @@
+# Cosmos-Lite v0.3.0 remote-policy smoke preset.
+#
+# Cosmos-Lite runs in its own Python 3.13/CUDA environment and exposes the
+# upstream OpenPI msgpack+NumPy WebSocket protocol.  This Zetta process is a
+# CPU client.  Replace the resolved-config path and manifest digest with the
+# values produced by the service before launching the Runtime.
+
+env_family: fake
+env_config:
+  action_dim: 8
+  chunk_size: 32
+  episode_length: 64
+  image_height: 540
+  image_width: 640
+  state_dim: 8
+  instruction: "move the robot arm to the requested target"
+
+gateway:
+  heartbeat_timeout_seconds: 60.0
+  heartbeat_interval_seconds: 10.0
+
+transport:
+  kind: inproc
+  command_timeout_seconds: 300.0
+
+env_worker:
+  group_name: env
+  num_ranks: 1
+  placement_strategy: node
+  max_sessions_per_rank: 1
+  default_pool_size: 1
+
+rollout_worker:
+  group_name: rollout
+  num_ranks: 1
+  placement_strategy: node
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  policy_id: cosmos_lite
+  policy_family: cosmos_lite
+  policy_backend: cosmos_lite
+  device: cpu
+  dtype: float32
+  max_concurrent_inferences: 1
+  policy_config:
+    endpoint: ws://127.0.0.1:8000
+    resolved_config_path: /data/cosmos_lite/runs/policy/server/resolved_deployment_config.json
+    expected_manifest_sha256: "<replace-with-64-char-manifest-sha256>"
+    expected_repository_revision: 2b5f5f3e8c02632f04432644ac0bf31780f554b5
+    action_dim: 8
+    actions_per_chunk: 32
+    joint_position_dim: 7
+    image_layout: single
+    connect_timeout_s: 5.0
+    request_timeout_s: 120.0
+    maximum_payload_bytes: 8388608
+    allow_insecure_remote: false
+    allow_dirty_upstream: false
+    allow_runtime_fallbacks: false
+  scheduler:
+    max_batch_size: 1
+    max_wait_ms: 0.0
+    max_queue_depth: 16
+    max_inflight_per_application: 4
+    max_inflight_per_session: 1
+    fixed_batch_size: null
+
+admission:
+  require_auth: false
+  tokens: {}
+  max_sessions_per_application: 4
+  max_inflight_operations_per_application: 8
+  max_inflight_operations_per_session: 2
+  max_total_inflight_operations: 16
+
+payload:
+  inline_threshold_bytes: 262144
+  request_limit_bytes: 8388608
+  image_codec: png

--- a/rollout_runtime/config/schema.py
+++ b/rollout_runtime/config/schema.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Zetta Contributors
 """Runtime configuration schema.
 
 Dataclass schema + omegaconf loading. ``omegaconf`` is imported lazily, only
@@ -188,7 +189,8 @@ class RolloutWorkerConfig:
         policy_id: The default policy identifier.
         policy_family: The policy family, which decides the allowed
             mixed-batching parameter set.
-        policy_backend: ``"fake"`` or ``"rlinf"`` (for openpi / pi0.5).
+        policy_backend: ``"fake"``, ``"zetta_openpi"``, ``"groot"``, or
+            ``"cosmos_lite"``.
             Both launchers read this via ``backends.build_policy_core``.
         policy_config: Backend-private policy configuration (for the
             ``rlinf`` backend, these are ``RlinfPolicyConfig``'s fields:
@@ -362,3 +364,24 @@ def _validate(config: RuntimeConfig) -> None:
             f"timeout={timeout}): a single missed probe would otherwise be enough to "
             "declare a live rank lost, and LOST sessions are not recoverable"
         )
+    rollout = config.rollout_worker
+    if rollout.policy_backend == "cosmos_lite":
+        if rollout.policy_family != "cosmos_lite":
+            raise ValueError(
+                "cosmos_lite backend requires rollout_worker.policy_family="
+                "'cosmos_lite'"
+            )
+        if rollout.num_ranks != 1:
+            raise ValueError("initial cosmos_lite backend requires num_ranks=1")
+        if rollout.max_concurrent_inferences != 1:
+            raise ValueError(
+                "initial cosmos_lite backend requires max_concurrent_inferences=1"
+            )
+        if rollout.scheduler.max_batch_size != 1:
+            raise ValueError(
+                "initial cosmos_lite backend requires scheduler.max_batch_size=1"
+            )
+        if rollout.scheduler.max_wait_ms != 0:
+            raise ValueError(
+                "initial cosmos_lite backend requires scheduler.max_wait_ms=0"
+            )

--- a/rollout_runtime/core/policy_inference.py
+++ b/rollout_runtime/core/policy_inference.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Zetta Contributors
 """Inference-core interface, batching-compatibility keys, and the
 mixable-parameter allowlist.
 
@@ -67,6 +68,9 @@ BATCHABLE_PARAM_KEYS: dict[str, frozenset[str]] = {
     "openpi_pytorch": frozenset({"noise_seed"}),
     "pi0": frozenset({"noise_seed"}),
     "pi05": frozenset({"noise_seed"}),
+    # Cosmos-Lite v0.3.0 is a batch-one remote server. Sampling parameters
+    # are fixed by its deployment YAML and checked by the backend.
+    "cosmos_lite": frozenset(),
     "fake": frozenset(),
 }
 """Per-policy-family declarations of "mixable" parameter keys: requests

--- a/scripts/deployment/smoke_cosmos_lite.py
+++ b/scripts/deployment/smoke_cosmos_lite.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Send deterministic Zetta requests to a running Cosmos-Lite service."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+from rollout_runtime.api.ids import EpisodeId, OperationSeq, RequestId, SessionId
+from rollout_runtime.api.internal import InferenceRequest
+from rollout_runtime.api.messages import Observation
+from rollout_runtime.backends.cosmos_lite import (
+    COSMOS_LITE_V030_REVISION,
+    CosmosLitePolicyConfig,
+    CosmosLitePolicyCore,
+)
+from rollout_runtime.core import payload as payload_module
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", default="ws://127.0.0.1:8000")
+    parser.add_argument("--resolved-config", type=Path, required=True)
+    parser.add_argument("--manifest-sha256", required=True)
+    parser.add_argument("--repository-revision", default=COSMOS_LITE_V030_REVISION)
+    parser.add_argument("--instruction", default="move the robot arm to the target")
+    parser.add_argument("--requests", type=int, default=2)
+    parser.add_argument("--request-timeout-s", type=float, default=900.0)
+    parser.add_argument("--action-atol", type=float, default=1e-6)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--include-actions",
+        action="store_true",
+        help="Include every returned action chunk in the JSON replay artifact.",
+    )
+    parser.add_argument("--allow-insecure-remote", action="store_true")
+    parser.add_argument("--allow-runtime-fallbacks", action="store_true")
+    return parser
+
+
+def _observation() -> Observation:
+    """Build a deterministic upstream-compatible single-image observation."""
+    rows = np.arange(540, dtype=np.uint16)[:, None, None]
+    columns = np.arange(640, dtype=np.uint16)[None, :, None]
+    channels = np.arange(3, dtype=np.uint16)[None, None, :]
+    image = ((rows + columns + channels * 31) % 256).astype(np.uint8)
+    return Observation(
+        session_id=SessionId("cosmos-lite-smoke"),
+        episode_id=EpisodeId(1),
+        step_index=0,
+        main_image=payload_module.encode_image(image),
+        state=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        instruction="",
+    )
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.requests < 1:
+        raise ValueError("--requests must be positive")
+    if args.action_atol < 0:
+        raise ValueError("--action-atol must be non-negative")
+    config = CosmosLitePolicyConfig(
+        endpoint=args.endpoint,
+        resolved_config_path=str(args.resolved_config),
+        expected_manifest_sha256=args.manifest_sha256,
+        expected_repository_revision=args.repository_revision,
+        image_layout="single",
+        request_timeout_s=args.request_timeout_s,
+        allow_insecure_remote=args.allow_insecure_remote,
+        allow_runtime_fallbacks=args.allow_runtime_fallbacks,
+    )
+    core = CosmosLitePolicyCore(config)
+    reports: list[dict[str, object]] = []
+    action_arrays: list[np.ndarray] = []
+    observation = _observation()
+    try:
+        core.load()
+        for index in range(args.requests):
+            request = InferenceRequest(
+                request_id=RequestId(f"cosmos-lite-smoke-{index}"),
+                session_id=observation.session_id,
+                episode_id=observation.episode_id,
+                operation_seq=OperationSeq(index + 1),
+                policy_id="cosmos_lite",
+                observation=observation,
+                instruction_override=args.instruction,
+                routing_token="smoke:0",
+                compat_key="cosmos-lite-smoke",
+                deadline=time.time() + args.request_timeout_s,
+            )
+            started = time.perf_counter()
+            response = core.infer_batch([request])[0]
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            if response.error is not None:
+                raise RuntimeError(
+                    f"{response.error.code.value}: {response.error.message}"
+                )
+            actions = payload_module.decode_payload(response.actions)
+            action_arrays.append(actions)
+            reports.append(
+                {
+                    "index": index,
+                    "latency_ms": elapsed_ms,
+                    "shape": list(actions.shape),
+                    "dtype": str(actions.dtype),
+                    "action_sha256": hashlib.sha256(actions.tobytes()).hexdigest(),
+                    "model_version": response.model_version,
+                    "auxiliary_outputs": response.auxiliary_outputs,
+                }
+            )
+            if args.include_actions:
+                reports[-1]["actions"] = actions.tolist()
+    finally:
+        core.close()
+
+    reference = action_arrays[0]
+    max_abs_diff = max(
+        (float(np.max(np.abs(actions - reference))) for actions in action_arrays[1:]),
+        default=0.0,
+    )
+    deterministic = max_abs_diff <= args.action_atol
+    report = {
+        "schema_version": 1,
+        "endpoint": args.endpoint,
+        "request_count": len(reports),
+        "deterministic": deterministic,
+        "action_atol": args.action_atol,
+        "max_action_abs_diff": max_abs_diff,
+        "input": {
+            "instruction": args.instruction,
+            "image_shape": [540, 640, 3],
+            "state": list(observation.state),
+        },
+        "requests": reports,
+    }
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    if not deterministic:
+        raise RuntimeError(
+            "fixed Cosmos-Lite seed exceeded action tolerance: "
+            f"{max_abs_diff} > {args.action_atol}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deployment/visualize_cosmos_lite_replay.py
+++ b/scripts/deployment/visualize_cosmos_lite_replay.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Render a self-contained HTML report from a Cosmos-Lite replay artifact."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import statistics
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_COLORS = (
+    "#63e6be",
+    "#74c0fc",
+    "#b197fc",
+    "#ffd43b",
+    "#ff8787",
+    "#4dabf7",
+    "#69db7c",
+    "#ffa94d",
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--title", default="Cosmos-Lite Model Replay")
+    return parser
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{field} must be finite")
+    return result
+
+
+def _percentile(values: Sequence[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("cannot calculate a percentile of an empty sequence")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def _fmt_ms(value: float | None) -> str:
+    if value is None:
+        return "—"
+    if value >= 1000:
+        return f"{value / 1000:.2f} s"
+    return f"{value:.1f} ms"
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _points(
+    values: Sequence[float | None],
+    *,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    minimum: float,
+    maximum: float,
+) -> str:
+    span = maximum - minimum or 1.0
+    denominator = max(len(values) - 1, 1)
+    points: list[str] = []
+    for index, value in enumerate(values):
+        if value is None:
+            continue
+        x = left + width * index / denominator
+        y = top + height * (maximum - value) / span
+        points.append(f"{x:.2f},{y:.2f}")
+    return " ".join(points)
+
+
+def _latency_chart(
+    client: Sequence[float],
+    server: Sequence[float | None],
+    *,
+    start_index: int,
+    title: str,
+) -> str:
+    visible_client = list(client[start_index:])
+    visible_server = list(server[start_index:])
+    numeric = visible_client + [value for value in visible_server if value is not None]
+    if not numeric:
+        return ""
+    chart_width = 960.0
+    chart_height = 300.0
+    left = 66.0
+    top = 30.0
+    plot_width = 860.0
+    plot_height = 210.0
+    maximum = max(numeric) * 1.08
+    minimum = 0.0
+    grid: list[str] = []
+    for tick in range(5):
+        ratio = tick / 4
+        y = top + plot_height * ratio
+        value = maximum * (1.0 - ratio)
+        grid.append(
+            f'<line x1="{left}" y1="{y:.2f}" x2="{left + plot_width}" '
+            'y2="{y:.2f}" class="grid" />'
+            f'<text x="{left - 10}" y="{y + 4:.2f}" text-anchor="end" '
+            f'class="axis-label">{value:.0f}</text>'
+        )
+    client_points = _points(
+        visible_client,
+        left=left,
+        top=top,
+        width=plot_width,
+        height=plot_height,
+        minimum=minimum,
+        maximum=maximum,
+    )
+    server_points = _points(
+        visible_server,
+        left=left,
+        top=top,
+        width=plot_width,
+        height=plot_height,
+        minimum=minimum,
+        maximum=maximum,
+    )
+    request_start = start_index + 1
+    request_end = start_index + len(visible_client)
+    return f"""
+      <section class="panel chart-panel">
+        <div class="section-heading">
+          <div><span class="eyebrow">LATENCY</span><h2>{_escape(title)}</h2></div>
+          <div class="legend"><span class="client-dot"></span>端到端
+          <span class="server-dot"></span>服务端推理</div>
+        </div>
+        <svg viewBox="0 0 {chart_width:.0f} {chart_height:.0f}" role="img"
+             aria-label="{_escape(title)}">
+          {"".join(grid)}
+          <line x1="{left}" y1="{top + plot_height}" x2="{left + plot_width}"
+                y2="{top + plot_height}" class="axis" />
+          <polyline points="{server_points}" class="server-line" />
+          <polyline points="{client_points}" class="client-line" />
+          <text x="{left}" y="{top + plot_height + 28}" class="axis-label">
+            请求 {request_start}</text>
+          <text x="{left + plot_width}" y="{top + plot_height + 28}"
+                text-anchor="end" class="axis-label">请求 {request_end}</text>
+          <text x="18" y="{top + plot_height / 2}" text-anchor="middle"
+                transform="rotate(-90 18 {top + plot_height / 2})"
+                class="axis-label">毫秒</text>
+        </svg>
+      </section>
+    """
+
+
+def _action_labels(dimension: int) -> list[str]:
+    if dimension == 8:
+        return [*(f"Joint {index + 1}" for index in range(7)), "Gripper"]
+    return [f"Action {index + 1}" for index in range(dimension)]
+
+
+def _validate_actions(value: Any) -> list[list[float]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("request.actions must be a non-empty matrix")
+    rows: list[list[float]] = []
+    width: int | None = None
+    for row_index, row in enumerate(value):
+        if not isinstance(row, list) or not row:
+            raise ValueError(f"request.actions[{row_index}] must be a non-empty list")
+        parsed = [
+            _number(item, f"request.actions[{row_index}][{column_index}]")
+            for column_index, item in enumerate(row)
+        ]
+        if width is None:
+            width = len(parsed)
+        elif len(parsed) != width:
+            raise ValueError("request.actions must be rectangular")
+        rows.append(parsed)
+    return rows
+
+
+def _action_charts(actions: list[list[float]] | None, request_count: int) -> str:
+    if actions is None:
+        return """
+          <section class="panel empty-state">
+            <span class="eyebrow">ACTION CHUNK</span>
+            <h2>动作轨迹未写入旧版 Replay</h2>
+            <p>重新运行 smoke 时增加 <code>--include-actions</code> 即可生成轨迹图。</p>
+          </section>
+        """
+    dimension = len(actions[0])
+    labels = _action_labels(dimension)
+    cards: list[str] = []
+    for column, label in enumerate(labels):
+        values = [row[column] for row in actions]
+        minimum = min(values)
+        maximum = max(values)
+        padding = max((maximum - minimum) * 0.1, 1e-6)
+        points = _points(
+            values,
+            left=24.0,
+            top=18.0,
+            width=292.0,
+            height=104.0,
+            minimum=minimum - padding,
+            maximum=maximum + padding,
+        )
+        zero = ""
+        if minimum <= 0 <= maximum:
+            zero_y = 18.0 + 104.0 * (maximum + padding) / (
+                maximum - minimum + 2 * padding
+            )
+            zero = (
+                f'<line x1="24" y1="{zero_y:.2f}" x2="316" '
+                f'y2="{zero_y:.2f}" class="zero-line" />'
+            )
+        cards.append(
+            f"""
+            <article class="action-card">
+              <div class="action-title"><strong>{_escape(label)}</strong>
+                <span>{minimum:.4f} → {maximum:.4f}</span></div>
+              <svg viewBox="0 0 340 150" role="img"
+                   aria-label="{_escape(label)} action trajectory">
+                {zero}
+                <polyline points="{points}" class="action-line"
+                          style="stroke:{_COLORS[column % len(_COLORS)]}" />
+                <text x="24" y="143" class="axis-label">step 1</text>
+                <text x="316" y="143" text-anchor="end" class="axis-label">
+                  step {len(values)}</text>
+              </svg>
+            </article>
+            """
+        )
+    return f"""
+      <section class="panel">
+        <div class="section-heading">
+          <div><span class="eyebrow">ACTION CHUNK</span><h2>{len(actions)} 步动作轨迹</h2></div>
+          <p class="muted">展示首个请求；{request_count} 次请求的一致性由 hash 和最大误差校验。</p>
+        </div>
+        <div class="action-grid">{"".join(cards)}</div>
+      </section>
+    """
+
+
+def _identity_table(
+    identity: dict[str, Any], model_version: str, action_sha256: str
+) -> str:
+    rows = [
+        ("Model version", model_version),
+        ("Action SHA256", action_sha256),
+        ("Model family", identity.get("model_family", "—")),
+        ("Strategy", identity.get("strategy", "—")),
+        ("Profile", identity.get("profile", "—")),
+        ("Artifact", identity.get("artifact", "—")),
+        ("Repository revision", identity.get("repository_revision", "—")),
+        ("Manifest SHA256", identity.get("manifest_sha256", "—")),
+        ("Resolved config SHA256", identity.get("resolved_config_sha256", "—")),
+    ]
+    body = "".join(
+        f"<tr><th>{_escape(label)}</th><td><code>{_escape(value)}</code></td></tr>"
+        for label, value in rows
+    )
+    return f"""
+      <section class="panel">
+        <span class="eyebrow">VERIFIED IDENTITY</span><h2>部署身份</h2>
+        <div class="table-wrap"><table>{body}</table></div>
+      </section>
+    """
+
+
+def _request_values(
+    requests: Sequence[dict[str, Any]],
+) -> tuple[list[float], list[float | None]]:
+    client: list[float] = []
+    server: list[float | None] = []
+    for index, request in enumerate(requests):
+        client.append(
+            _number(request.get("latency_ms"), f"requests[{index}].latency_ms")
+        )
+        auxiliary = request.get("auxiliary_outputs")
+        timing = auxiliary.get("server_timing") if isinstance(auxiliary, dict) else None
+        infer_ms = timing.get("infer_ms") if isinstance(timing, dict) else None
+        server.append(
+            None
+            if infer_ms is None
+            else _number(infer_ms, f"requests[{index}].server_timing.infer_ms")
+        )
+    return client, server
+
+
+def _unique_nonempty(values: Iterable[Any]) -> list[str]:
+    return sorted({str(value) for value in values if value not in (None, "")})
+
+
+def render_report(payload: dict[str, Any], *, title: str, source: str) -> str:
+    """Render one validated replay payload as standalone HTML."""
+    requests_value = payload.get("requests")
+    if not isinstance(requests_value, list) or not requests_value:
+        raise ValueError("replay report must contain at least one request")
+    if not all(isinstance(item, dict) for item in requests_value):
+        raise ValueError("replay requests must be objects")
+    requests: list[dict[str, Any]] = requests_value
+    client, server = _request_values(requests)
+    warm_client = client[1:] or client
+    warm_server = [value for value in server[1:] if value is not None]
+    if not warm_server:
+        warm_server = [value for value in server if value is not None]
+    hashes = _unique_nonempty(request.get("action_sha256") for request in requests)
+    versions = _unique_nonempty(request.get("model_version") for request in requests)
+    first = requests[0]
+    shape = first.get("shape", "—")
+    shape_text = (
+        "×".join(str(value) for value in shape)
+        if isinstance(shape, list)
+        else str(shape)
+    )
+    deterministic = payload.get("deterministic") is True
+    max_diff = _number(payload.get("max_action_abs_diff", 0.0), "max_action_abs_diff")
+    action_data = first.get("actions")
+    actions = None if action_data is None else _validate_actions(action_data)
+    auxiliary = first.get("auxiliary_outputs")
+    identity_value = (
+        auxiliary.get("cosmos_lite_identity") if isinstance(auxiliary, dict) else None
+    )
+    identity = identity_value if isinstance(identity_value, dict) else {}
+    model_version = versions[0] if len(versions) == 1 else f"{len(versions)} versions"
+    input_value = payload.get("input")
+    replay_input = input_value if isinstance(input_value, dict) else {}
+    instruction = replay_input.get("instruction", "—")
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    cold_latency = client[0]
+    p50_client = statistics.median(warm_client)
+    p95_client = _percentile(warm_client, 0.95)
+    p50_server = statistics.median(warm_server) if warm_server else None
+    status_class = "pass" if deterministic and len(hashes) == 1 else "fail"
+    status_text = "PASS · 完全一致" if status_class == "pass" else "CHECK · 存在差异"
+    cards = (
+        ("请求数", str(len(requests)), "连续真实推理"),
+        ("确定性", status_text, f"最大误差 {max_diff:.2g}"),
+        (
+            "动作输出",
+            f"{shape_text} · {first.get('dtype', '—')}",
+            f"{len(hashes)} 个唯一 hash",
+        ),
+        ("冷启动", _fmt_ms(cold_latency), "包含首次编译"),
+        ("热态 P50", _fmt_ms(p50_client), f"P95 {_fmt_ms(p95_client)}"),
+        ("服务端 P50", _fmt_ms(p50_server), "排除首次请求"),
+    )
+    cards_html = "".join(
+        f"""
+        <article class="metric"><span>{_escape(label)}</span>
+          <strong class="{status_class if label == "确定性" else ""}">{_escape(value)}</strong>
+          <small>{_escape(note)}</small></article>
+        """
+        for label, value, note in cards
+    )
+    action_html = _action_charts(actions, len(requests))
+    all_latency = _latency_chart(client, server, start_index=0, title="全量请求延迟")
+    warm_latency = (
+        _latency_chart(
+            client, server, start_index=1, title="热态请求延迟（排除首次编译）"
+        )
+        if len(client) > 1
+        else ""
+    )
+    return f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{_escape(title)}</title>
+  <style>
+    :root {{ color-scheme: dark; --bg:#07111f; --panel:#101d2d; --line:#263b52;
+      --text:#eef6ff; --muted:#9db0c5; --teal:#63e6be; --blue:#74c0fc;
+      --red:#ff8787; }}
+    * {{ box-sizing:border-box; }}
+    body {{ margin:0; background:radial-gradient(circle at 15% 0,#17314b 0,#07111f 42%);
+      color:var(--text); font:15px/1.55 Inter,ui-sans-serif,system-ui,sans-serif; }}
+    main {{ width:min(1180px,calc(100% - 32px)); margin:0 auto; padding:48px 0 72px; }}
+    header {{ margin-bottom:28px; }}
+    h1 {{ margin:5px 0 8px; font-size:clamp(30px,5vw,54px); letter-spacing:-.035em; }}
+    h2 {{ margin:4px 0 12px; font-size:22px; }}
+    p {{ margin:0; }} .muted, .meta {{ color:var(--muted); }}
+    .eyebrow {{ color:var(--teal); font-size:12px; font-weight:800; letter-spacing:.14em; }}
+    .metrics {{ display:grid; grid-template-columns:repeat(3,1fr); gap:14px; margin:24px 0; }}
+    .metric,.panel,.action-card {{ background:linear-gradient(145deg,rgba(18,34,52,.96),rgba(11,24,39,.96));
+      border:1px solid var(--line); border-radius:16px; box-shadow:0 16px 45px rgba(0,0,0,.18); }}
+    .metric {{ padding:18px; min-height:126px; }} .metric span,.metric small {{ display:block;color:var(--muted); }}
+    .metric strong {{ display:block;margin:8px 0 5px;font-size:22px; }}
+    .metric strong.pass {{ color:var(--teal); }} .metric strong.fail {{ color:var(--red); }}
+    .panel {{ padding:22px; margin-top:16px; }} .chart-panel svg {{ width:100%; min-height:260px; }}
+    .section-heading {{ display:flex;justify-content:space-between;gap:20px;align-items:flex-end; }}
+    .legend {{ color:var(--muted);white-space:nowrap; }}
+    .client-dot,.server-dot {{ display:inline-block;width:9px;height:9px;border-radius:50%;margin:0 6px 0 14px; }}
+    .client-dot {{ background:var(--teal); }} .server-dot {{ background:var(--blue); }}
+    .grid {{ stroke:#20344a;stroke-width:1; }} .axis {{ stroke:#51667d;stroke-width:1; }}
+    .axis-label {{ fill:#8298ae;font-size:12px; }}
+    .client-line,.server-line,.action-line {{ fill:none;stroke-linecap:round;stroke-linejoin:round; }}
+    .client-line {{ stroke:var(--teal);stroke-width:3; }} .server-line {{ stroke:var(--blue);stroke-width:2;opacity:.8; }}
+    .action-grid {{ display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin-top:18px; }}
+    .action-card {{ padding:14px;background:#0b1827; }} .action-card svg {{ width:100%; }}
+    .action-title {{ display:flex;justify-content:space-between;color:var(--muted); }}
+    .action-title strong {{ color:var(--text); }} .action-line {{ stroke-width:3; }}
+    .zero-line {{ stroke:#42566b;stroke-width:1;stroke-dasharray:4 4; }}
+    .table-wrap {{ overflow:auto; }} table {{ width:100%;border-collapse:collapse; }}
+    th,td {{ padding:10px 8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top; }}
+    th {{ width:190px;color:var(--muted);font-weight:500; }} code {{ color:#c5f6fa;overflow-wrap:anywhere; }}
+    .empty-state {{ border-style:dashed;text-align:center;padding:42px; }}
+    footer {{ color:var(--muted);margin-top:22px;font-size:13px; }}
+    @media (max-width:760px) {{ .metrics,.action-grid {{ grid-template-columns:1fr; }}
+      .section-heading {{ align-items:flex-start;flex-direction:column; }} .legend {{ white-space:normal; }} }}
+  </style>
+</head>
+<body><main>
+  <header><span class="eyebrow">ZETTA × NVIDIA COSMOS-LITE</span>
+    <h1>{_escape(title)}</h1>
+    <p class="meta">输入指令：{_escape(instruction)} · 生成时间：{_escape(generated_at)}</p>
+  </header>
+  <section class="metrics">{cards_html}</section>
+  {all_latency}
+  {warm_latency}
+  {action_html}
+  {_identity_table(identity, model_version, hashes[0] if len(hashes) == 1 else "—")}
+  <footer>数据源：<code>{_escape(source)}</code> · 报告为自包含 HTML，无外部资源。</footer>
+</main></body></html>
+"""
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("replay report root must be an object")
+    rendered = render_report(payload, title=args.title, source=str(args.input))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/fixtures/cosmos_lite/resolved_deployment_config.json
+++ b/tests/runtime/fixtures/cosmos_lite/resolved_deployment_config.json
@@ -1,0 +1,93 @@
+{
+  "bundle": {
+    "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "model_family": "cosmos3_policy",
+    "path": "/data/cosmos_lite/quantized_bundle",
+    "strategy": "gen_branch_w8a8"
+  },
+  "created_at": "2026-08-25T00:00:00+00:00",
+  "effective": {
+    "model": {
+      "artifact": "quantized_bundle",
+      "bundle_dir": "/data/cosmos_lite/quantized_bundle",
+      "checkpoint_path": null,
+      "family": "cosmos3_policy",
+      "strategy": "gen_branch_w8a8"
+    },
+    "profile": "cosmos_lite_quantized_4090",
+    "runtime": {
+      "attention_backend": "sage_attention",
+      "backend_policy": "strict",
+      "condition_kv_cache": true,
+      "fp8_gemm_backend": "triton_sm89",
+      "fp8_projection_fusion": "shared",
+      "torch_compile": true
+    },
+    "sampling": {
+      "denoise_steps": 2,
+      "deterministic_seed": true,
+      "guidance": 3.0,
+      "seed": 0,
+      "shift": 5.0
+    },
+    "schema_version": 1,
+    "server": {
+      "format_prompt_as_json": false,
+      "host": "127.0.0.1",
+      "output_dir": "/data/cosmos_lite/runs/test",
+      "port": 8000,
+      "profile_jsonl": null
+    }
+  },
+  "fallback_decisions": [],
+  "model": {
+    "artifact": "quantized_bundle",
+    "bundle_path": "/data/cosmos_lite/quantized_bundle",
+    "checkpoint_path": null,
+    "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "model_family": "cosmos3_policy",
+    "strategy": "gen_branch_w8a8"
+  },
+  "repository": {
+    "dirty": false,
+    "revision": "2b5f5f3e8c02632f04432644ac0bf31780f554b5",
+    "root": "/opt/cosmos-lite"
+  },
+  "requested": {
+    "model": {
+      "artifact": "quantized_bundle",
+      "bundle_dir": "/data/cosmos_lite/quantized_bundle",
+      "checkpoint_path": null,
+      "family": "cosmos3_policy",
+      "strategy": "gen_branch_w8a8"
+    },
+    "profile": "cosmos_lite_quantized_4090",
+    "runtime": {
+      "attention_backend": "sage_attention",
+      "backend_policy": "strict"
+    },
+    "sampling": {
+      "denoise_steps": 2,
+      "deterministic_seed": true,
+      "guidance": 3.0,
+      "seed": 0,
+      "shift": 5.0
+    },
+    "schema_version": 1,
+    "server": {
+      "host": "127.0.0.1",
+      "port": 8000
+    }
+  },
+  "runtime_probe": {
+    "compute_capability": [8, 9],
+    "cuda_available": true,
+    "cuda_version": "12.8",
+    "gpu_name": "NVIDIA GeForce RTX 4090",
+    "sageattention_installed": true,
+    "sageattention_sm89": true,
+    "torch_version": "2.10.0+cu128",
+    "triton_installed": true
+  },
+  "schema_version": 1
+}

--- a/tests/runtime/test_cosmos_lite_backend.py
+++ b/tests/runtime/test_cosmos_lite_backend.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Contract tests for the Cosmos-Lite remote policy backend."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from rollout_runtime.api.enums import ErrorCode
+from rollout_runtime.api.ids import EpisodeId, OperationSeq, RequestId, SessionId
+from rollout_runtime.api.internal import InferenceRequest
+from rollout_runtime.api.messages import Observation
+from rollout_runtime.backends import build_policy_core, policy_compat_constraints
+from rollout_runtime.backends.cosmos_lite import (
+    COSMOS_LITE_V030_REVISION,
+    CosmosLitePolicyConfig,
+    CosmosLitePolicyCore,
+    _pack_message,
+    _unpack_message,
+)
+from rollout_runtime.config.schema import load_config
+from rollout_runtime.core import payload as payload_module
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "cosmos_lite"
+    / "resolved_deployment_config.json"
+)
+MANIFEST_SHA256 = "a" * 64
+
+
+class _FakeTransport:
+    """In-memory stand-in for one OpenPI WebSocket connection."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.closed = False
+        self.connect_calls = 0
+        self.infer_calls: list[tuple[dict[str, Any], float]] = []
+        self.metadata: dict[str, Any] = {}
+        self.response: Any = {
+            "action": np.zeros((32, 8), dtype=np.float32),
+            "server_timing": {"infer_ms": 12.5},
+        }
+        self.failure: BaseException | None = None
+
+    def connect(self) -> dict[str, Any]:
+        self.connect_calls += 1
+        self.connected = True
+        return dict(self.metadata)
+
+    def infer(self, observation: dict[str, Any], *, timeout_s: float) -> dict[str, Any]:
+        self.infer_calls.append((observation, timeout_s))
+        if self.failure is not None:
+            raise self.failure
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+        self.connected = False
+
+
+def _config(**overrides: Any) -> CosmosLitePolicyConfig:
+    values: dict[str, Any] = {
+        "resolved_config_path": str(FIXTURE),
+        "expected_manifest_sha256": MANIFEST_SHA256,
+        "image_layout": "single",
+    }
+    values.update(overrides)
+    return CosmosLitePolicyConfig(**values)
+
+
+def _request(index: int = 0, **overrides: Any) -> InferenceRequest:
+    image = payload_module.encode_image(np.full((4, 6, 3), index, dtype=np.uint8))
+    observation = Observation(
+        session_id=SessionId(f"sess-{index}"),
+        episode_id=EpisodeId(1),
+        step_index=index,
+        main_image=image,
+        wrist_image=payload_module.encode_image(
+            np.full((4, 6, 3), index + 1, dtype=np.uint8)
+        ),
+        extra_view_images=[
+            payload_module.encode_image(np.full((4, 6, 3), index + 2, dtype=np.uint8))
+        ],
+        state=[float(value) for value in range(8)],
+        instruction="put the banana in the bowl",
+    )
+    values: dict[str, Any] = {
+        "request_id": RequestId(f"req-{index}"),
+        "session_id": SessionId(f"sess-{index}"),
+        "episode_id": EpisodeId(1),
+        "operation_seq": OperationSeq(index + 1),
+        "policy_id": "cosmos_lite",
+        "observation": observation,
+        "routing_token": "env:0",
+        "compat_key": "compat",
+    }
+    values.update(overrides)
+    return InferenceRequest(**values)
+
+
+def _loaded_core(transport: _FakeTransport, **overrides: Any) -> CosmosLitePolicyCore:
+    core = CosmosLitePolicyCore(
+        _config(**overrides), transport_factory=lambda _config: transport
+    )
+    core.load()
+    return core
+
+
+def test_openpi_msgpack_numpy_contract_round_trips_arrays() -> None:
+    request = {
+        "prompt": "move",
+        "observation/image": np.arange(18, dtype=np.uint8).reshape(2, 3, 3),
+        "observation/joint_position": np.arange(7, dtype=np.float32),
+    }
+    decoded = _unpack_message(_pack_message(request))
+    assert decoded["prompt"] == "move"
+    np.testing.assert_array_equal(
+        decoded["observation/image"], request["observation/image"]
+    )
+    np.testing.assert_array_equal(
+        decoded["observation/joint_position"],
+        request["observation/joint_position"],
+    )
+
+
+def test_load_verifies_identity_and_connects() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    assert transport.connect_calls == 1
+    assert core.loaded is True
+    assert core.model_version.startswith("cosmos-lite:cosmos3_policy:")
+    core.load()
+    assert transport.connect_calls == 1
+    core.close()
+    assert transport.closed is True
+
+
+def test_interface_contract_changes_the_derived_model_version() -> None:
+    single = _loaded_core(_FakeTransport(), image_layout="single")
+    three_view = _loaded_core(_FakeTransport(), image_layout="robolab_three_view")
+    try:
+        assert single.model_version != three_view.model_version
+    finally:
+        single.close()
+        three_view.close()
+
+
+def test_model_version_cannot_override_verified_identity() -> None:
+    with pytest.raises(ValueError, match="derived from its verified deployment"):
+        build_policy_core(
+            backend="cosmos_lite",
+            policy_config=dataclasses.asdict(_config()),
+            model_version="manual-label",
+        )
+
+
+def test_identity_mismatch_fails_before_connecting(tmp_path: Path) -> None:
+    record = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    record["model"]["manifest_sha256"] = "b" * 64
+    resolved = tmp_path / "resolved.json"
+    resolved.write_text(json.dumps(record), encoding="utf-8")
+    transport = _FakeTransport()
+    core = CosmosLitePolicyCore(
+        _config(resolved_config_path=str(resolved)),
+        transport_factory=lambda _config: transport,
+    )
+    with pytest.raises(ValueError, match="manifest mismatch"):
+        core.load()
+    assert transport.connect_calls == 0
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda record: record["repository"].update({"dirty": True}),
+            "repository must be clean",
+        ),
+        (
+            lambda record: record.update({"fallback_decisions": ["use_sdpa"]}),
+            "contains runtime fallbacks",
+        ),
+        (
+            lambda record: record["effective"]["sampling"].update(
+                {"deterministic_seed": False}
+            ),
+            "deterministic_seed=true",
+        ),
+        (
+            lambda record: record["effective"]["sampling"].update(
+                {"deterministic_seed": "false"}
+            ),
+            "deterministic_seed=true",
+        ),
+        (
+            lambda record: record["bundle"].update({"manifest_sha256": "b" * 64}),
+            "bundle identity does not match",
+        ),
+        (
+            lambda record: record["runtime_probe"].update({"cuda_available": False}),
+            "cuda_available=true",
+        ),
+    ],
+)
+def test_unverified_deployment_is_rejected_before_connecting(
+    tmp_path: Path, mutate: Any, message: str
+) -> None:
+    record = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    mutate(record)
+    resolved = tmp_path / "resolved.json"
+    resolved.write_text(json.dumps(record), encoding="utf-8")
+    transport = _FakeTransport()
+    core = CosmosLitePolicyCore(
+        _config(resolved_config_path=str(resolved)),
+        transport_factory=lambda _config: transport,
+    )
+    with pytest.raises(ValueError, match=message):
+        core.load()
+    assert transport.connect_calls == 0
+
+
+def test_single_view_request_maps_to_upstream_and_returns_actions() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    request = _request(
+        instruction_override="override prompt",
+        inference_parameters={"mode": "eval", "seed": 0, "num_steps": 2},
+    )
+    response = core.infer_batch([request])[0]
+    assert response.error is None
+    assert response.model_version == core.model_version
+    actions = payload_module.decode_payload(response.actions)
+    assert actions.shape == (32, 8)
+    assert actions.dtype == np.float32
+    upstream, timeout_s = transport.infer_calls[0]
+    assert upstream["prompt"] == "override prompt"
+    assert upstream["observation/image"].shape == (4, 6, 3)
+    np.testing.assert_array_equal(
+        upstream["observation/joint_position"], np.arange(7, dtype=np.float32)
+    )
+    np.testing.assert_array_equal(
+        upstream["observation/gripper_position"], np.array([7], dtype=np.float32)
+    )
+    assert timeout_s == pytest.approx(120.0)
+    assert response.auxiliary_outputs["server_timing"] == {"infer_ms": 12.5}
+    assert (
+        response.auxiliary_outputs["cosmos_lite_identity"]["manifest_sha256"]
+        == MANIFEST_SHA256
+    )
+
+
+def test_three_view_layout_uses_upstream_robolab_keys() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport, image_layout="robolab_three_view")
+    response = core.infer_batch([_request()])[0]
+    assert response.error is None
+    upstream = transport.infer_calls[0][0]
+    assert "observation/image" not in upstream
+    assert upstream["observation/wrist_image_left"][0, 0, 0] == 1
+    assert upstream["observation/exterior_image_1_left"][0, 0, 0] == 0
+    assert upstream["observation/exterior_image_2_left"][0, 0, 0] == 2
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        ({}, "no 'action'"),
+        ({"action": np.zeros((31, 8), dtype=np.float32)}, "shape mismatch"),
+        ({"action": np.full((32, 8), np.nan, dtype=np.float32)}, "NaN or Inf"),
+    ],
+)
+def test_invalid_service_response_is_policy_failure(
+    response: dict[str, Any], message: str
+) -> None:
+    transport = _FakeTransport()
+    transport.response = response
+    core = _loaded_core(transport)
+    result = core.infer_batch([_request()])[0]
+    assert result.error is not None
+    assert result.error.code is ErrorCode.POLICY_FAILURE
+    assert message in result.error.message
+
+
+def test_invalid_request_isolated_without_calling_service() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    original = _request().observation
+    invalid = dataclasses.replace(original, state=[0.0] * 7)
+    result = core.infer_batch([_request(observation=invalid)])[0]
+    assert result.error is not None
+    assert result.error.code is ErrorCode.INVALID_ARGUMENT
+    assert transport.infer_calls == []
+
+
+def test_non_numeric_state_is_invalid_argument() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    original = _request().observation
+    invalid = dataclasses.replace(original, state=["bad"] * 8)
+    result = core.infer_batch([_request(observation=invalid)])[0]
+    assert result.error is not None
+    assert result.error.code is ErrorCode.INVALID_ARGUMENT
+    assert "state is not numeric" in result.error.message
+    assert transport.infer_calls == []
+
+
+def test_timeout_is_deadline_exceeded_and_is_not_retried() -> None:
+    transport = _FakeTransport()
+    transport.failure = TimeoutError("server timed out")
+    core = _loaded_core(transport)
+    result = core.infer_batch([_request(deadline=time.time() + 1.0)])[0]
+    assert result.error is not None
+    assert result.error.code is ErrorCode.DEADLINE_EXCEEDED
+    assert len(transport.infer_calls) == 1
+
+
+def test_server_fixed_sampling_parameter_mismatch_is_rejected() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    result = core.infer_batch([_request(inference_parameters={"guidance": 4.0})])[0]
+    assert result.error is not None
+    assert result.error.code is ErrorCode.INVALID_ARGUMENT
+    assert "fixed by the Cosmos-Lite service" in result.error.message
+
+
+def test_insecure_non_loopback_endpoint_is_rejected() -> None:
+    with pytest.raises(ValueError, match="restricted to loopback"):
+        _config(endpoint="ws://10.0.0.8:8000")
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("device", "cuda:0", "requires device='cpu'"),
+        ("dtype", "float16", "requires dtype='float32'"),
+    ],
+)
+def test_remote_client_execution_contract_is_fixed(
+    key: str, value: str, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _config(**{key: value})
+
+
+def test_backend_registration_and_constraints() -> None:
+    config = dataclasses.asdict(_config())
+    core = build_policy_core(
+        backend="cosmos_lite",
+        policy_config=config,
+        device="cpu",
+        dtype="float32",
+        policy_family="cosmos_lite",
+        action_dim=8,
+        actions_per_chunk=32,
+    )
+    assert isinstance(core, CosmosLitePolicyCore)
+    constraints = policy_compat_constraints(backend="cosmos_lite", policy_config=config)
+    assert constraints["action_dim"] == 8
+    assert constraints["actions_per_chunk"] == 32
+    assert constraints["expected_manifest_sha256"] == MANIFEST_SHA256
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("policy_family", "fake", "policy_family='cosmos_lite'"),
+        ("num_ranks", 2, "requires num_ranks=1"),
+        ("max_concurrent_inferences", 2, "requires max_concurrent_inferences=1"),
+        ("scheduler.max_batch_size", 2, "scheduler.max_batch_size=1"),
+        ("scheduler.max_wait_ms", 1.0, "scheduler.max_wait_ms=0"),
+    ],
+)
+def test_runtime_config_requires_single_request_scheduling(
+    field: str, value: Any, message: str
+) -> None:
+    rollout = {
+        "policy_id": "cosmos_lite",
+        "policy_family": "cosmos_lite",
+        "policy_backend": "cosmos_lite",
+        "num_ranks": 1,
+        "max_concurrent_inferences": 1,
+        "policy_config": {
+            "resolved_config_path": str(FIXTURE),
+            "expected_manifest_sha256": MANIFEST_SHA256,
+        },
+        "scheduler": {"max_batch_size": 1, "max_wait_ms": 0.0},
+    }
+    if field.startswith("scheduler."):
+        rollout["scheduler"][field.removeprefix("scheduler.")] = value
+    else:
+        rollout[field] = value
+    with pytest.raises(ValueError, match=message):
+        load_config({"rollout_worker": rollout})
+
+
+def test_hot_weight_update_is_rejected() -> None:
+    transport = _FakeTransport()
+    core = _loaded_core(transport)
+    with pytest.raises(RuntimeError, match="does not support runtime weight updates"):
+        core.update_weights("new-version")
+
+
+def test_config_is_pinned_to_cosmos_lite_v030() -> None:
+    config = _config()
+    assert config.expected_repository_revision == COSMOS_LITE_V030_REVISION
+
+
+def test_packaged_preset_selects_cosmos_lite_backend() -> None:
+    config = load_config("cosmos_lite_remote")
+    assert config.rollout_worker.policy_backend == "cosmos_lite"
+    assert config.rollout_worker.policy_family == "cosmos_lite"
+    assert config.rollout_worker.device == "cpu"
+    assert config.rollout_worker.dtype == "float32"
+    assert config.rollout_worker.scheduler.max_batch_size == 1

--- a/tests/runtime/test_cosmos_lite_replay_visualization.py
+++ b/tests/runtime/test_cosmos_lite_replay_visualization.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Tests for the self-contained Cosmos-Lite replay report."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "deployment"
+    / "visualize_cosmos_lite_replay.py"
+)
+
+
+def _request(index: int, *, include_actions: bool = True) -> dict[str, object]:
+    request: dict[str, object] = {
+        "index": index,
+        "latency_ms": 400.0 + index,
+        "shape": [2, 2],
+        "dtype": "float32",
+        "action_sha256": "stable-hash",
+        "model_version": "cosmos-lite:test:1234",
+        "auxiliary_outputs": {
+            "server_timing": {"infer_ms": 390.0 + index},
+            "cosmos_lite_identity": {
+                "model_family": "cosmos3_edge",
+                "strategy": "gen_branch_w8a8",
+                "manifest_sha256": "a" * 64,
+            },
+        },
+    }
+    if include_actions:
+        request["actions"] = [[0.0, 1.0], [0.5, 0.25]]
+    return request
+
+
+def _render(tmp_path: Path, *, include_actions: bool) -> str:
+    source = tmp_path / "replay.json"
+    output = tmp_path / "replay.html"
+    source.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "deterministic": True,
+                "max_action_abs_diff": 0.0,
+                "input": {"instruction": "move <safely>"},
+                "requests": [
+                    _request(0, include_actions=include_actions),
+                    _request(1, include_actions=include_actions),
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(source),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert str(output) in completed.stdout
+    return output.read_text(encoding="utf-8")
+
+
+def test_visualizer_generates_self_contained_action_and_latency_charts(
+    tmp_path: Path,
+) -> None:
+    rendered = _render(tmp_path, include_actions=True)
+    assert "Cosmos-Lite Model Replay" in rendered
+    assert "全量请求延迟" in rendered
+    assert "热态请求延迟" in rendered
+    assert "2 步动作轨迹" in rendered
+    assert "stable-hash" in rendered
+    assert "move &lt;safely&gt;" in rendered
+    assert rendered.count("<svg") == 4
+    assert "https://" not in rendered
+
+
+def test_visualizer_explains_how_to_upgrade_legacy_report(tmp_path: Path) -> None:
+    rendered = _render(tmp_path, include_actions=False)
+    assert "动作轨迹未写入旧版 Replay" in rendered
+    assert "--include-actions" in rendered

--- a/tests/runtime/test_layering.py
+++ b/tests/runtime/test_layering.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Zetta Contributors
 """Layered import guard (five rules governing module boundaries).
 
 Uses AST scanning of import nodes without executing the module — this way the
@@ -75,6 +76,7 @@ RUNTIME_TOOLING_FILES = frozenset(
         "scripts/deployment/m7_acceptance/rr_lost_probe.py",
         "scripts/deployment/m7_acceptance/rr_eval_batching.py",
         "scripts/deployment/m7_acceptance/rr_serve_overhead.py",
+        "scripts/deployment/smoke_cosmos_lite.py",
         "scripts/experiments/run_ab_runtime.py",
         "scripts/experiments/run_concurrency_ab.py",
         "scripts/experiments/libero_critic_recovery_latency_v3.py",
@@ -116,6 +118,9 @@ allowlist is a tool belonging to runtime itself (in the same category as
 - ``m7_acceptance/rr_serve_overhead.py``: a ``policy_step`` micro-benchmark
   across the embedded / ASGI / TCP arms, providing the per-round-trip cost
   (required in the repository per an independent audit requirement).
+- ``smoke_cosmos_lite.py``: a deployment probe for the optional remote
+  Cosmos-Lite policy backend; it exercises Runtime protocol conversion but
+  does not enter any legacy robot path.
 - ``run_concurrency_ab.py``: a **concurrent** A/B driver for legacy vs.
   rollout, where both arms share the same scripted workload definition (no
   planner). The rollout arm installs its own runtime (``launch/`` +


### PR DESCRIPTION
Add Cosmos-Lite support as a remote policy backend in `rollout_runtime`.

  - Add `CosmosLitePolicyCore` and WebSocket client integration.
  - Register the `cosmos_lite` policy backend and configuration schema.
  - Add a reusable remote deployment preset.
  - Validate model identity using the resolved deployment configuration and bundle manifest.
  - Validate request payloads, response shapes, action dimensions, finite values, timeouts, and
  endpoint security.
  - Add deployment smoke-test and deterministic replay visualization utilities.
  - Add backend, replay visualization, and architecture-layering tests.

  ## Architecture

  Cosmos-Lite remains an independent model service. Zetta only implements the client and Runtime
  backend:

  ```text
  InferenceRequest
      -> CosmosLitePolicyCore
      -> Cosmos-Lite WebSocket Service
      -> Cosmos3 Model
      -> ActionResponse

  The Cosmos model is not loaded inside the Zetta process.

  ## Validation

  Executed on the air-4090 validation host:

  python -m pytest -q \
    tests/runtime/test_cosmos_lite_backend.py \
    tests/runtime/test_cosmos_lite_replay_visualization.py \
    tests/runtime/test_layering.py

  Result:

  49 passed in 3.03s

  Formatting and linting:

  uvx ruff check --ignore CPY001 <changed-python-files>
  uvx ruff format --check <changed-python-files>

  Results:

  All checks passed!
  9 files already formatted

  The implementation was also validated against a real Cosmos-Lite service using the cosmos3_edge/
  gen_branch_w8a8 model, including a 100-request replay and HTML visualization generation.

  ## Deployment Notes

  - Install the client dependency with the cosmos-lite optional dependency.
  - Real inference requires a separately deployed Cosmos-Lite CUDA service.
  - The model identity, resolved deployment configuration, and manifest should be pinned for
    reproducible runs.

  - The Zetta-side client can run on CPU; GPU selection belongs to the Cosmos-Lite service.

  ## Scope

  This PR intentionally excludes:

  - Documentation files.
  - RoboLab integration and RoboLab-120 evaluation.
  - LIBERO or RoboCasa model adaptation.
  - Model weights, replay outputs, videos, and machine-specific paths.
  - Runtime model hot-swapping.