### PR TITLE
fix(planner): qualify bare API model aliases

### DIFF
--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -548,3 +548,25 @@ def test_build_planner_uses_external_central_broker_when_configured(
     )
     assert not isinstance(planner._model, FailoverModel)
     assert str(planner._model.base_url).rstrip("/") == "http://127.0.0.1:4110/v1"
+
+
+@pytest.mark.parametrize("model_name", ["gpt-5.6-sol", "deployment-alias"])
+def test_build_planner_qualifies_bare_model_for_openai_responses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, model_name: str
+):
+    monkeypatch.delenv(PROVIDERS_ENV, raising=False)
+    monkeypatch.delenv("ZETTA_API_PROVIDER_BROKER_URL", raising=False)
+    monkeypatch.delenv("ZETTA_API_PROVIDER_BROKER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    planner = build_planner(
+        "api",
+        output_dir=tmp_path,
+        recipe_tag="test-openai-alias",
+        env_name="libero",
+        base_url="https://provider.invalid/v1",
+        model=model_name,
+        reasoning_effort="xhigh",
+    )
+
+    assert planner._model.model_name == model_name

--- a/zetta/planner/base.py
+++ b/zetta/planner/base.py
@@ -124,6 +124,13 @@ def build_planner(
                 "'openai:gpt-5.5', 'openai-chat:glm-5.2')."
             )
 
+        # Campaign manifests intentionally keep stable deployment aliases such
+        # as ``gpt-5.6-sol`` instead of coupling the frozen protocol to
+        # pydantic-ai's provider syntax.  The API planner's default transport
+        # is OpenAI Responses, so qualify every bare alias at this boundary.
+        # Explicit provider-qualified names remain unchanged.
+        api_model_name = model if ":" in model else f"openai-responses:{model}"
+
         import inspect
 
         from pydantic_ai.models import infer_model
@@ -154,7 +161,7 @@ def build_planner(
                 kwargs["base_url"] = base_url
             return provider_cls(**kwargs)
 
-        provider_pool = load_provider_pool_config(default_model=model)
+        provider_pool = load_provider_pool_config(default_model=api_model_name)
         provider_broker = load_provider_broker_connection()
         if provider_broker is not None:
             if provider_pool is None:
@@ -168,7 +175,9 @@ def build_planner(
                 api_key=broker_api_key,
             )
         elif provider_pool is None:
-            api_model = infer_model(model, provider_factory=_provider_factory)
+            api_model = infer_model(
+                api_model_name, provider_factory=_provider_factory
+            )
         else:
             api_model = build_provider_pool_model(provider_pool)
         return ApiAgentLoop(


### PR DESCRIPTION
## Summary

Fixes the API planner failure where LIBERO campaign preparation accepts bare model aliases but infer_model() cannot resolve them.

## Root cause

Campaign preparation accepts stable bare aliases such as gpt-5.6-luna and stores them in the manifest. However, the API planner passed the bare alias directly to pydantic-ai model resolution.

This caused errors such as:

    UserError: Unknown model: gpt-5.6-luna

The failure happened before the first LIBERO rollout, so every attempt was classified as infra_invalid.

## Fix

- Qualify bare model aliases as openai-responses:<model> at the API planner boundary.
- Preserve explicitly provider-qualified model names unchanged.
- Use the qualified name consistently for provider-pool lookup and model inference.
- Keep the original model alias available for planner metadata and audit records.
- Add regression coverage for a supported OpenAI alias and an arbitrary deployment alias.

The change does not modify model weights, reasoning effort, prompts, actions, environment settings, or rollout evaluation semantics. It only makes model names already accepted by campaign preparation resolvable by the configured OpenAI-compatible Responses endpoint.

## Validation

- Provider-pool regression tests: 22 passed.
- Ruff passed.
- An additional isolated planner-construction probe passed for gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra, gpt-5.5, gpt-5.2, gpt-4o, and gpt-4.1.
- The additional probe used a dummy key and an invalid endpoint, so it verified model-name resolution only and did not send model requests.