### PR TITLE
fix(evolution): isolate stage evidence access

### DIFF
--- a/tests/test_codex_provider_broker.py
+++ b/tests/test_codex_provider_broker.py
@@ -33,15 +33,21 @@ def test_codex_uses_external_broker_instead_of_per_solve_proxy(
         output_dir=str(tmp_path),
         model="gpt-5.6-sol",
         reasoning_effort="high",
+        sandbox="read-only",
+        native_tools=False,
     )
 
     assert planner._external_provider_broker == (
         "http://127.0.0.1:4110",
         "local-broker-key",
     )
+    assert planner._sandbox.value == "read-only"
+    assert planner._native_tools is False
     config = planner._build_config("http://127.0.0.1:9999")
     overrides = "\n".join(config.config_overrides)
     assert 'model_providers.zetta_proxy.base_url="http://127.0.0.1:4110/v1"' in overrides
     assert 'model_reasoning_effort="high"' in overrides
+    assert "features.shell_tool=false" in overrides
+    assert "tools.view_image=false" in overrides
     assert config.env[PROVIDER_ENV_KEY] == "local-broker-key"
     assert "upstream-secret" not in overrides

--- a/tests/test_evolution_lifecycle.py
+++ b/tests/test_evolution_lifecycle.py
@@ -37,6 +37,7 @@ from zetta.evolution.models import (
     RecoveryRule,
     RecoveryStep,
 )
+from zetta.evolution.stages import CodexStageAgent
 from zetta.evolution.store import CampaignStore
 
 
@@ -238,6 +239,7 @@ def test_first_candidate_resumes_hashed_diagnosis_context(tmp_path: Path) -> Non
         {
             "session_id": "campaign-session",
             "provider_thread_id": "diagnosis-thread",
+            "evidence_policy": CodexStageAgent.EVIDENCE_POLICY,
         },
         overwrite=False,
     )
@@ -246,6 +248,7 @@ def test_first_candidate_resumes_hashed_diagnosis_context(tmp_path: Path) -> Non
         {
             "session_id": "stale-session",
             "provider_thread_id": "stale-thread",
+            "evidence_policy": CodexStageAgent.EVIDENCE_POLICY,
         },
         overwrite=False,
     )
@@ -287,6 +290,7 @@ def test_latest_stage2_context_skips_unregistered_proposal_directory(
             {
                 "session_id": "campaign-session",
                 "provider_thread_id": f"provider-{index}",
+                "evidence_policy": CodexStageAgent.EVIDENCE_POLICY,
             },
         )
         atomic_write_json(
@@ -294,6 +298,7 @@ def test_latest_stage2_context_skips_unregistered_proposal_directory(
             {
                 "session_id": "campaign-session",
                 "provider_thread_id": f"provider-{index}",
+                "evidence_policy": CodexStageAgent.EVIDENCE_POLICY,
                 "successful_attempt": "attempt-000",
                 "output_sha256": canonical_sha256(output),
             },

--- a/tests/test_evolution_stage_session.py
+++ b/tests/test_evolution_stage_session.py
@@ -296,6 +296,7 @@ def test_stage_recovers_completed_attempt_after_validator_fix(
             "reasoning_effort": "high",
             "provider_reported_resumed": True,
             "reconstructed": False,
+            "evidence_policy": agent.EVIDENCE_POLICY,
             "error": None,
         },
         overwrite=False,
@@ -326,10 +327,83 @@ def test_stage_recovers_completed_attempt_after_validator_fix(
         "reasoning_effort": "high",
         "resumed": True,
         "reconstructed": False,
+        "evidence_policy": agent.EVIDENCE_POLICY,
         "successful_attempt": "attempt-000",
         "output_sha256": canonical_sha256(recovered),
         "revalidated_completed_attempt": True,
     }
+
+
+def test_stage_exposes_only_audited_evidence_capabilities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePlanner:
+        def solve(self, **kwargs: Any) -> PlannerResult:
+            captured["tool_names"] = {
+                str(spec["name"])
+                for spec in kwargs["toolkit"].get_tools_spec()
+            }
+            return PlannerResult(
+                messages=[{"content": json.dumps({"accepted": True})}],
+                stats={"thread_id": "thread-evidence-only"},
+            )
+
+    def build(kind: str, **kwargs: Any) -> FakePlanner:
+        assert kind == "codex"
+        captured["build"] = kwargs
+        return FakePlanner()
+
+    monkeypatch.setattr("zetta.evolution.stages.build_planner", build)
+    root = tmp_path / "candidate"
+    result = CodexStageAgent(
+        output_root=root,
+        artifact_reader=lambda _content_id: {"kind": "structured"},
+    )._invoke(
+        stage="evidence-only",
+        system_prompt="system",
+        payload={"bounded": True},
+        validator=lambda value: None,
+    )
+
+    assert result == {"accepted": True}
+    assert captured["tool_names"] == {
+        "describe_tools",
+        "read_campaign_artifact",
+    }
+    build_kwargs = captured["build"]
+    assert build_kwargs["codex_repo_root"] == (
+        root / "evidence-only" / "attempt-000"
+    )
+    assert build_kwargs["codex_sandbox"] == "read-only"
+    assert build_kwargs["codex_native_tools"] is False
+
+
+def test_stage_rejects_context_that_predates_evidence_isolation(
+    tmp_path: Path,
+) -> None:
+    stage = tmp_path / "stage2-proposal"
+    stage.mkdir()
+    atomic_write_json(stage / "input.json", {"bounded": True}, overwrite=False)
+    atomic_write_json(stage / "output.json", {"accepted": True}, overwrite=False)
+    atomic_write_json(
+        stage / "context.json",
+        {
+            "session_id": "legacy-session",
+            "provider_thread_id": "legacy-thread",
+            "stage": "stage2-proposal",
+            "successful_attempt": "attempt-000",
+        },
+        overwrite=False,
+    )
+
+    with pytest.raises(ValueError, match="predates enforced evidence isolation"):
+        CodexStageAgent(output_root=tmp_path)._invoke(
+            stage="stage2-proposal",
+            system_prompt="system",
+            payload={"bounded": True},
+        )
 
 
 def _diagnosis() -> CausalDiagnosis:

--- a/tests/test_generalist_integration.py
+++ b/tests/test_generalist_integration.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Zetta Contributors
 from __future__ import annotations
 
 import unittest
@@ -79,6 +80,17 @@ class GeneralistIntegrationTests(unittest.TestCase):
             reasoning_summary="detailed",
         )
         self.assertIn('model_reasoning_summary="detailed"', overrides)
+
+    def test_codex_restricted_profile_disables_native_file_tools(self):
+        overrides = _codex_mcp_config_overrides(
+            mcp_url="http://127.0.0.1:1/mcp",
+            base_url=None,
+            native_tools=False,
+        )
+        self.assertIn("features.shell_tool=false", overrides)
+        self.assertIn("features.shell_snapshot=false", overrides)
+        self.assertIn("tools.view_image=false", overrides)
+        self.assertIn("tools.web_search=false", overrides)
 
     def test_codex_recorder_reads_nested_total_usage(self):
         recorder = _Recorder(max_turns=2)

--- a/zetta/evolution/lifecycle.py
+++ b/zetta/evolution/lifecycle.py
@@ -1555,6 +1555,7 @@ def _active_stage1_context(store: CampaignStore) -> dict[str, Any]:
         if not context_path.is_file():
             continue
         context = read_json(context_path)
+        CodexStageAgent.require_evidence_policy(context, stage="Stage1")
         output_path = stage_root / "output.json"
         if output_path.is_file():
             output = read_json(output_path)
@@ -1639,6 +1640,7 @@ def _latest_stage2_context(store: CampaignStore) -> dict[str, Any]:
 
         path = stage_root / "context.json"
         context = read_json(path)
+        CodexStageAgent.require_evidence_policy(context, stage="Stage2")
         output_path = stage_root / "output.json"
         output = read_json(output_path)
         if context.get("output_sha256") != canonical_sha256(output):
@@ -4146,6 +4148,7 @@ def run_diagnosis_stage(
         context = _latest_stage2_context(store)
     elif cluster_context_path.is_file():
         context = read_json(cluster_context_path)
+        CodexStageAgent.require_evidence_policy(context, stage="Cluster Agent")
         successful_attempt = context.get("successful_attempt")
         cluster_attempt_root = (
             cluster_context_path.parent / str(successful_attempt)

--- a/zetta/evolution/stages.py
+++ b/zetta/evolution/stages.py
@@ -932,6 +932,8 @@ def _diagnosis_visual_contract(
 class CodexStageAgent:
     """One audited Codex invocation per stage with explicit transcript carryover."""
 
+    EVIDENCE_POLICY = "audited-mcp-only-v1"
+
     def __init__(
         self,
         *,
@@ -1133,6 +1135,8 @@ class CodexStageAgent:
                     ):
                         continue
                     metadata = read_json(attempt_invocation)
+                    if metadata.get("evidence_policy") != self.EVIDENCE_POLICY:
+                        continue
                     provider_thread_id = metadata.get("provider_thread_id")
                     if (
                         not isinstance(provider_thread_id, str)
@@ -1149,6 +1153,7 @@ class CodexStageAgent:
                             "reasoning_effort": metadata.get("reasoning_effort"),
                             "resumed": bool(metadata["provider_reported_resumed"]),
                             "reconstructed": bool(metadata["reconstructed"]),
+                            "evidence_policy": self.EVIDENCE_POLICY,
                             "successful_attempt": attempt.name,
                             "output_sha256": canonical_sha256(recovered_output),
                             "context_recovered_after_commit": True,
@@ -1161,6 +1166,7 @@ class CodexStageAgent:
                         f"{stage} output exists without a recoverable provider context"
                     )
             context = read_json(context_path)
+            self.require_evidence_policy(context, stage=stage)
             self.session_id = str(context["session_id"])
             self.thread_id = context.get("provider_thread_id")
             self.reconstructed = bool(context.get("reconstructed", False))
@@ -1205,6 +1211,8 @@ class CodexStageAgent:
                 continue
             metadata = read_json(attempt_invocation)
             if metadata.get("error"):
+                continue
+            if metadata.get("evidence_policy") != self.EVIDENCE_POLICY:
                 continue
             recorded_input_sha256 = metadata.get("input_sha256")
             if input_revision and recorded_input_sha256 != payload_sha256:
@@ -1261,6 +1269,7 @@ class CodexStageAgent:
                     "reasoning_effort": metadata.get("reasoning_effort"),
                     "resumed": bool(metadata.get("provider_reported_resumed", False)),
                     "reconstructed": bool(metadata.get("reconstructed", False)),
+                    "evidence_policy": self.EVIDENCE_POLICY,
                     "successful_attempt": attempt.name,
                     "output_sha256": canonical_sha256(recovered),
                     "revalidated_completed_attempt": True,
@@ -1285,9 +1294,6 @@ class CodexStageAgent:
             self._add_evidence_tool(toolkit, access_log=access_log)
             available = {str(spec["name"]) for spec in toolkit.get_tools_spec()}
             allowed = available & {
-                "read_text_file",
-                "read_image",
-                "list_files",
                 "describe_tools",
                 "read_campaign_artifact",
             }
@@ -1309,6 +1315,9 @@ class CodexStageAgent:
                     reasoning_effort=self.reasoning_effort,
                     planner_timeout_s=self.timeout_s,
                     codex_thread_id=resume_thread_id,
+                    codex_repo_root=attempt,
+                    codex_sandbox="read-only",
+                    codex_native_tools=False,
                 )
                 result = planner.solve(
                     system_prompt=effective_system,
@@ -1344,6 +1353,7 @@ class CodexStageAgent:
                 "provider_thread_id": stats.get("thread_id"),
                 "provider_reported_resumed": bool(stats.get("thread_resumed", False)),
                 "reconstructed": reconstruct,
+                "evidence_policy": self.EVIDENCE_POLICY,
                 "error": result.error,
                 "stats": stats,
                 "transcript_sha256": canonical_sha256(result.messages),
@@ -1410,6 +1420,7 @@ class CodexStageAgent:
                 "reasoning_effort": self.reasoning_effort,
                 "resumed": bool(metadata["provider_reported_resumed"]),
                 "reconstructed": self.reconstructed,
+                "evidence_policy": self.EVIDENCE_POLICY,
                 "successful_attempt": metadata["attempt"],
                 "output_sha256": canonical_sha256(parsed),
                 **input_revision,
@@ -1417,6 +1428,17 @@ class CodexStageAgent:
             overwrite=False,
         )
         return parsed
+
+    @classmethod
+    def require_evidence_policy(
+        cls, context: dict[str, Any], *, stage: str
+    ) -> None:
+        """Reject provider context created before filesystem evidence isolation."""
+        if context.get("evidence_policy") != cls.EVIDENCE_POLICY:
+            raise ValueError(
+                f"{stage} context predates enforced evidence isolation; "
+                "start a fresh campaign"
+            )
 
     @staticmethod
     def _validate_visual_access(

--- a/zetta/planner/base.py
+++ b/zetta/planner/base.py
@@ -110,6 +110,9 @@ def build_planner(
     dashboard: Any = None,
     no_images: bool = False,
     codex_thread_id: str | None = None,
+    codex_repo_root: str | Path | None = None,
+    codex_sandbox: str | None = None,
+    codex_native_tools: bool = True,
     reasoning_effort: str | None = None,
 ):
     """Build a planner for the given backend, resolving credentials from env vars."""
@@ -211,7 +214,7 @@ def build_planner(
             )
         return CodexPlanner(
             output_dir=output_dir,
-            repo_root=get_repo_root(),
+            repo_root=codex_repo_root or get_repo_root(),
             model=model,
             reasoning_effort=reasoning_effort,
             timeout_s=cx_timeout_s,
@@ -219,5 +222,7 @@ def build_planner(
             output_path=Path(output_dir) / f"codex_{recipe_tag}.txt",
             dashboard=dashboard,
             resume_thread_id=codex_thread_id,
+            sandbox=codex_sandbox,
+            native_tools=codex_native_tools,
         )
     raise ValueError(f"unknown planner_type: {planner_type}")

--- a/zetta/planner/codex.py
+++ b/zetta/planner/codex.py
@@ -73,6 +73,8 @@ class CodexPlanner:
         reasoning_effort: str | None = None,
         dashboard: Any = None,
         resume_thread_id: str | None = None,
+        sandbox: str | None = None,
+        native_tools: bool = True,
     ):
         """Initialize the Codex SDK backend."""
         self._output_dir = str(output_dir)
@@ -94,7 +96,10 @@ class CodexPlanner:
         self._external_provider_broker = load_provider_broker_connection()
         self._provider_proxy_base_url: str | None = None
         self._provider_proxy_api_key: str | None = None
-        self._sandbox = _sandbox_from_env()
+        self._sandbox = (
+            _sandbox_from_env() if sandbox is None else _sandbox_from_name(sandbox)
+        )
+        self._native_tools = bool(native_tools)
         self._dashboard = dashboard
         if resume_thread_id is not None and not str(resume_thread_id).strip():
             raise ValueError("resume_thread_id must be non-empty when provided")
@@ -274,6 +279,7 @@ class CodexPlanner:
                     else "default"
                 ),
                 "sandbox": self._sandbox.value,
+                "native_tools": self._native_tools,
                 "elapsed_s": round(elapsed, 1),
                 "output_chars": len(text),
                 "output_path": str(output_path),
@@ -484,6 +490,7 @@ class CodexPlanner:
                     base_url=effective_base_url,
                     reasoning_effort=self._reasoning_effort,
                     reasoning_summary=self._reasoning_summary,
+                    native_tools=self._native_tools,
                 )
             ),
             "cwd": self._repo_root,
@@ -503,7 +510,12 @@ class CodexPlanner:
 
 def _sandbox_from_env() -> Any:
     """Resolve the planner sandbox without weakening the historical default."""
-    requested = os.environ.get("ZETTA_CODEX_SANDBOX", "full-access").strip().lower()
+    return _sandbox_from_name(os.environ.get("ZETTA_CODEX_SANDBOX", "full-access"))
+
+
+def _sandbox_from_name(requested: str) -> Any:
+    """Resolve one explicit Codex sandbox name."""
+    normalized = requested.strip().lower()
     aliases = {
         "read-only": openai_codex.Sandbox.read_only,
         "readonly": openai_codex.Sandbox.read_only,
@@ -512,11 +524,11 @@ def _sandbox_from_env() -> Any:
         "full": openai_codex.Sandbox.full_access,
     }
     try:
-        return aliases[requested]
+        return aliases[normalized]
     except KeyError as exc:
         raise ValueError(
             "ZETTA_CODEX_SANDBOX must be read-only, workspace-write, or full-access; "
-            f"got {requested!r}"
+            f"got {normalized!r}"
         ) from exc
 
 
@@ -716,11 +728,21 @@ def _codex_mcp_config_overrides(
     base_url: str | None,
     reasoning_effort: str | None = None,
     reasoning_summary: str | None = None,
+    native_tools: bool = True,
 ) -> list[str]:
     config: list[tuple[str, Any]] = [
         ("mcp_servers.zetta.url", mcp_url),
         ("mcp_servers.zetta.required", True),
     ]
+    if not native_tools:
+        config.extend(
+            [
+                ("features.shell_tool", False),
+                ("features.shell_snapshot", False),
+                ("tools.view_image", False),
+                ("tools.web_search", False),
+            ]
+        )
     if base_url:
         normalized = base_url.rstrip("/")
         if not normalized.endswith("/v1"):


### PR DESCRIPTION
## Summary

Fixes an evidence-isolation issue where Stage Agents could bypass the audited artifact interface and read files from other campaigns through native filesystem tools.

## Root cause

The Stage toolkit limited access to audited Zetta artifact tools, but Codex native shell, file-listing, image, and web tools remained available.

When the audited artifact-read budget was exhausted, a Stage Agent could still inspect adjacent campaign directories and consume historical outputs that were not part of the current immutable checkpoint.

This could contaminate diagnosis, clustering, or candidate generation and invalidate seed-blind reproduction.

## Fix

- Restrict Stage Agents to describe_tools and the audited read_campaign_artifact interface.
- Run each invocation from its own attempt directory.
- Force the Stage sandbox to read-only.
- Disable native shell, shell snapshot, local image, and web tools.
- Record evidence_policy=audited-mcp-only-v1 in invocation and context metadata.
- Reject old contexts created before evidence isolation was enforced.
- Keep the existing Codex planner defaults unchanged for non-stage callers.

The fix does not change the LIBERO environment, policy weights, action generation, or Shadow Replay rules. For a clean invocation that only uses permitted evidence, the Stage result should remain unchanged. Results may differ when the previous invocation relied on hidden or cross-campaign files; that difference is intentional.

## Validation

- Planner and evolution regression tests: 223 passed, 1 deselected.
- Ruff and git diff --check passed.
- A real Luna canary placed in an adjacent campaign directory was not read.
- The native-tool transcript contained no unauthorized filesystem calls.