### PR TITLE
fix(critic): evaluate activation guards before features

### DIFF
--- a/rollout_runtime/backends/libero_critic.py
+++ b/rollout_runtime/backends/libero_critic.py
@@ -312,7 +312,6 @@ class TemporalCritic:
         proposals: list[dict[str, Any]] = []
         for rule in self.rules:
             state = self._state[rule.rule_id]
-            value = resolve_feature(observation, rule.feature)
             if not all(
                 self._predicate(condition, observation)
                 for condition in rule.activation_conditions
@@ -324,6 +323,7 @@ class TemporalCritic:
                 state.cooldown_remaining = 0
                 state.history.clear()
                 continue
+            value = resolve_feature(observation, rule.feature)
             state.history.append(value)
             if len(state.history) > rule.dwell_steps:
                 state.history.pop(0)

--- a/tests/runtime/test_libero_critic_recovery.py
+++ b/tests/runtime/test_libero_critic_recovery.py
@@ -29,6 +29,7 @@ environment on a remote Linux GPU host, which is not the responsibility of
 this file.
 """
 
+# Copyright (c) 2026 Zetta Contributors
 from __future__ import annotations
 
 from typing import Any
@@ -194,6 +195,57 @@ def test_hit_rule_populates_proposals_and_interrupts_by_default(
     assert proposals[0]["step_index"] == 2
     assert proposals[0]["environment_write"] is False
     assert outcome.info["critic_rule_count"] == 1
+    core.close()
+
+
+def test_activation_guard_skips_unavailable_primary_feature(
+    stub_rlinf: type[_StubLiberoEnv],
+) -> None:
+    """A false availability guard must protect a missing primary feature.
+
+    ``robot.eef.motion_m`` is intentionally absent on the first physical
+    step, before ``critic_previous_eef`` exists.  The guard is false on that
+    frame, then becomes true together with the feature on the second frame.
+    This exercises the complete online ``LiberoEnvCore.chunk_step`` path.
+
+    Args:
+        stub_rlinf: rlinf stub fixture.
+    """
+    core = _build_core()
+    core.reset(
+        [0],
+        ResetSpec(
+            task_id=0,
+            seed=0,
+            options={
+                "critic_rules": [
+                    {
+                        "rule_id": "eef-motion-available",
+                        "feature": "robot.eef.motion_m",
+                        "operator": "ge",
+                        "threshold": 0.0,
+                        "dwell_steps": 1,
+                        "proposal": "EEF motion became available",
+                        "activation_conditions": [
+                            {
+                                "feature": "robot.eef.delta_available",
+                                "operator": "eq",
+                                "threshold": True,
+                            }
+                        ],
+                    }
+                ]
+            },
+        ),
+    )
+
+    outcome = core.chunk_step([0], [_action_block(5)])[0]
+
+    assert outcome.executed_horizon == 2
+    assert [proposal["rule_id"] for proposal in outcome.info["critic_proposals"]] == [
+        "eef-motion-available"
+    ]
+    assert outcome.info["critic_proposals"][0]["step_index"] == 2
     core.close()
 
 

--- a/tests/test_critic_feature_guard_alignment.py
+++ b/tests/test_critic_feature_guard_alignment.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Zetta Contributors
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from rollout_runtime.backends.libero_critic import (
+    CriticPredicate as RuntimeCriticPredicate,
+)
+from rollout_runtime.backends.libero_critic import CriticRule as RuntimeCriticRule
+from rollout_runtime.backends.libero_critic import (
+    TemporalCritic as RuntimeTemporalCritic,
+)
+from zetta.evolution.critic import TemporalCritic as EvolutionTemporalCritic
+from zetta.evolution.models import CriticPredicate, CriticRule
+
+
+def _evolution_critic() -> EvolutionTemporalCritic:
+    return EvolutionTemporalCritic(
+        (
+            CriticRule(
+                rule_id="eef-motion",
+                title="EEF motion is low",
+                feature="robot.eef.motion_m",
+                operator="le",
+                threshold=0.0,
+                dwell_steps=1,
+                cooldown_steps=0,
+                proposal="recover EEF motion",
+                evidence_ids=("segment-eef-motion",),
+                activation_conditions=(
+                    CriticPredicate(
+                        feature="robot.eef.delta_available",
+                        operator="eq",
+                        threshold=True,
+                    ),
+                ),
+            ),
+        )
+    )
+
+
+def _runtime_critic() -> RuntimeTemporalCritic:
+    return RuntimeTemporalCritic(
+        (
+            RuntimeCriticRule(
+                rule_id="eef-motion",
+                title="EEF motion is low",
+                feature="robot.eef.motion_m",
+                operator="le",
+                threshold=0.0,
+                dwell_steps=1,
+                cooldown_steps=0,
+                proposal="recover EEF motion",
+                activation_conditions=(
+                    RuntimeCriticPredicate(
+                        feature="robot.eef.delta_available",
+                        operator="eq",
+                        threshold=True,
+                    ),
+                ),
+            ),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "critic_factory",
+    [_evolution_critic, _runtime_critic],
+    ids=["evolution", "libero-runtime"],
+)
+def test_activation_guard_controls_primary_feature_availability(
+    critic_factory: Callable[[], Any],
+) -> None:
+    critic = critic_factory()
+
+    assert (
+        critic.evaluate(
+            {"robot.eef.delta_available": False},
+            step_index=1,
+        )
+        == []
+    )
+
+    with pytest.raises(
+        KeyError,
+        match="critic feature is unavailable: robot.eef.motion_m",
+    ):
+        critic.evaluate(
+            {"robot.eef.delta_available": True},
+            step_index=2,
+        )
+
+    proposals = critic.evaluate(
+        {
+            "robot.eef.delta_available": True,
+            "robot.eef.motion_m": 0.0,
+        },
+        step_index=3,
+    )
+    assert [proposal["rule_id"] for proposal in proposals] == ["eef-motion"]
+    assert proposals[0]["activation_conditions"][0]["observed_value"] is True

--- a/zetta/evolution/critic.py
+++ b/zetta/evolution/critic.py
@@ -58,7 +58,6 @@ class TemporalCritic:
         proposals: list[dict[str, Any]] = []
         for rule in self.rules:
             state = self._state[rule.rule_id]
-            value = resolve_feature(observation, rule.feature)
             if not all(
                 self._predicate(condition, observation)
                 for condition in rule.activation_conditions
@@ -69,6 +68,7 @@ class TemporalCritic:
                 state.cooldown_remaining = 0
                 state.history.clear()
                 continue
+            value = resolve_feature(observation, rule.feature)
             state.history.append(value)
             if len(state.history) > rule.dwell_steps:
                 state.history.pop(0)


### PR DESCRIPTION
## Summary

Fixes the first-step LIBERO Critic failure reported in #24:

    INVALID_ARGUMENT: critic feature is unavailable: robot.eef.motion_m

## Root cause

After reset, the new LiberoEnvCore does not yet have a previous EEF position for the first physical action. Therefore, displacement-derived features such as robot.eef.motion_m and command.realization.eef_motion_m are unavailable on that frame.

Both Critic implementations resolved the primary rule feature before evaluating activation conditions. A rule guarded by robot.eef.delta_available == false therefore attempted to resolve an unavailable feature and raised a KeyError.

The live runtime normalized this error to INVALID_ARGUMENT and marked the rollout as infra_invalid, while Shadow Replay handled the missing prefix feature differently and could still admit the candidate.

## Fix

- Evaluate all activation conditions before resolving the primary feature.
- When a guard is false, clear the rule's temporal state and skip feature resolution.
- When a guard is true but the primary feature is missing, preserve fail-closed KeyError behavior.
- Apply the same ordering in:
  - rollout_runtime/backends/libero_critic.py
  - zetta/evolution/critic.py
- Add cross-implementation alignment coverage and a full LIBERO first-step/second-step runtime regression.

The fix does not modify model inputs, action generation, thresholds, dwell semantics, cooldown semantics, or valid-rule behavior. It only prevents a valid availability guard from being bypassed by premature feature resolution.

This PR does not initialize critic_previous_eef at reset and does not add a close-while-stalled regression; those changes should be described separately if submitted.

## Validation

- Critic and LIBERO regression tests: 23 passed.
- Ruff passed.