### PR TITLE
fix(queue): expose abandoned claim recovery

### DIFF
--- a/tests/test_evolution_queue_recovery.py
+++ b/tests/test_evolution_queue_recovery.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
@@ -12,6 +14,7 @@ import pytest
 
 import zetta.evolution.queue as queue_module
 from zetta.evolution.campaign import _known_job_ids, ingest_queue_results
+from zetta.evolution.cli import main as evolution_cli_main
 from zetta.evolution.jsonio import atomic_write_json, read_json
 from zetta.evolution.models import CampaignManifest, EpisodeRecord
 from zetta.evolution.queue import RolloutJob, SharedHostQueue, run_worker
@@ -312,6 +315,47 @@ def test_claim_after_crash_closes_once_and_fences_late_worker(
             result=read_json(terminal)["result"],
             claim_token=token,
         )
+
+
+def test_recover_abandoned_cli_closes_stale_claim_idempotently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    queue = SharedHostQueue(tmp_path / "queue")
+    job = _job(tmp_path)
+    claimed, _, _ = _claim(queue, job)
+    _make_stale(claimed)
+    command = [
+        "zetta.evolution.cli",
+        "recover-abandoned",
+        "--queue-root",
+        str(queue.root),
+        "--host",
+        "host-a",
+        "--stale-after-s",
+        "30",
+    ]
+
+    monkeypatch.setattr(sys, "argv", command)
+    assert evolution_cli_main() == 0
+    first = json.loads(capsys.readouterr().out)
+    assert first == {
+        "host": "host-a",
+        "recovered": 1,
+        "queue": {
+            "pending": 0,
+            "running": 0,
+            "completed": 0,
+            "failed": 1,
+        },
+    }
+
+    monkeypatch.setattr(sys, "argv", command)
+    assert evolution_cli_main() == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second["recovered"] == 0
+    assert second["queue"] == first["queue"]
 
 
 def test_published_episode_result_is_adopted_after_worker_crash(

--- a/zetta/evolution/cli.py
+++ b/zetta/evolution/cli.py
@@ -173,6 +173,14 @@ def _parser() -> argparse.ArgumentParser:
     worker.add_argument("--slot-broker-root")
     worker.add_argument("--environment-ready-manifest")
     worker.add_argument("--maximum-active-environment-slots", type=int)
+
+    recover = commands.add_parser(
+        "recover-abandoned",
+        help="append-only close abandoned queue claims without replaying side effects",
+    )
+    recover.add_argument("--queue-root", required=True)
+    recover.add_argument("--host", required=True)
+    recover.add_argument("--stale-after-s", type=float, required=True)
     return parser
 
 
@@ -382,6 +390,20 @@ def main() -> int:
             environment_ready_manifest=args.environment_ready_manifest,
             maximum_active_environment_slots=args.maximum_active_environment_slots,
         )
+    if args.command == "recover-abandoned":
+        queue = SharedHostQueue(args.queue_root)
+        recovered = queue.recover_abandoned(
+            args.host,
+            stale_after_s=args.stale_after_s,
+        )
+        _print(
+            {
+                "host": args.host,
+                "recovered": recovered,
+                "queue": queue.counts(),
+            }
+        )
+        return 0
     raise AssertionError(args.command)
 
 


### PR DESCRIPTION
## Summary

Fixes a queue lifecycle issue where an interrupted worker could leave a claim permanently stuck in running, causing the campaign gate to wait indefinitely.

## Root cause

SharedHostQueue.recover_abandoned() already implemented fencing, published-result adoption, and append-only terminal recovery, but the production CLI and campaign workflow provided no way to invoke it.

After a worker process exited before committing its result, the claim remained in running. Restarted workers only processed pending jobs, while the campaign driver only consumed terminal envelopes.

## Fix

- Add the zetta.evolution.cli recover-abandoned command.
- Require an explicit queue root, host, and stale-claim threshold.
- Report the number of recovered claims and the resulting queue counts.
- Preserve fencing and append-only terminal commit semantics.
- Adopt an already-published result when one exists.
- Do not move stale claims directly back to pending or replay side effects.

The default worker and campaign behavior is unchanged until the recovery command is explicitly invoked. When invoked, the command only closes confirmed stale claims so the existing retry policy can make the next decision.

## Validation

- Queue recovery and run-campaign regression tests: 20 passed.
- Recovery is idempotent: repeating the command does not create duplicate terminal records.
- A stale production claim was closed with commit_source=recovery, and the queue returned to running=0.