### PR TITLE
feat: Add RoboTwin environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zetta is an efficient closed-loop embodied harness for self-evolving physical in
 - [√] **August 19, 2026:** Open-source Z-Infra with LIBERO support.
 - [√] **August 20, 2026:** Add RoboCasa support.
 - [√] **August 27, 2026:** Add NVIDIA Cosmos model support.
-- [ ] **September 3, 2026:** Add RoboTwin environment support.
+- [√] **September 3, 2026:** Add RoboTwin environment support.
 - [ ] **September 10, 2026:** Add ManiSkill environment support.
 - [ ] **September 17, 2026:** Add BEHAVIOR environment support.
 - [ ] **Ongoing:** Expand model and environment coverage at an approximate cadence of one integration per week.
@@ -44,8 +44,8 @@ Runtime role boundaries:
 | Path | Purpose |
 |---|---|
 | `zetta/evolution/` | Immutable manifests, queues, clustering, stages, gates, promotion, and supervision |
-| `rollout_runtime/` | The Rollout Runtime: Gateway, EnvWorker/RolloutWorker groups, and backends for LIBERO/RoboCasa/ManiSkill |
-| `robots/libero/`, `robots/robocasa/` | Env clients, Role1/Critic/Recovery, tools, and rendering contracts |
+| `rollout_runtime/` | The Rollout Runtime: Gateway, EnvWorker/RolloutWorker groups, and backends for LIBERO/RoboCasa/ManiSkill/RoboTwin |
+| `robots/libero/`, `robots/robocasa/`, `robots/robotwin/` | Env clients, Role1/Critic/Recovery, tools, and rendering contracts |
 | `scripts/evolution/` | Campaign preparation, workers, capacity probes, and plots |
 | `scripts/deployment/` | Service start/stop, VLA env install, and Docker build helpers |
 | `tests/` | Unit/contract tests; the minimal set requires no simulator or model |
@@ -114,6 +114,35 @@ python -m robocasa.scripts.setup_macros              # set up system variables
 python -m robocasa.scripts.download_kitchen_assets   # downloads ~10GB of kitchen assets
 ```
 
+**RoboTwin 2.0 + Pi0.5**
+
+RoboTwin is SAPIEN-based and cannot share a venv with either track above. Use the
+upstream RLinf image rather than building one:
+
+```bash
+git clone https://github.com/RoboTwin-Platform/RoboTwin.git -b RLinf_support
+# then download ~15GB of assets into its assets/ directory
+
+docker run --rm --gpus all --shm-size 32g \
+  -e NVIDIA_DISABLE_REQUIRE=1 \
+  -e NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics \
+  -e LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/cuda/lib64 \
+  --device /dev/dri \
+  -v "$ROBOTWIN_ROOT":/workspace/RoboTwin \
+  -v "$REPO_ROOT":/workspace/Zetta \
+  --entrypoint /bin/bash rlinf/rlinf:agentic-rlinf0.4-robotwin
+```
+
+The image ships three venvs under `/opt/venv/`; this repository uses `openpi`.
+The three environment variables let a CUDA 12.8 image run on a 12.4 driver:
+`NVIDIA_DISABLE_REQUIRE` skips the image's `cuda>=12.8` label check,
+`NVIDIA_DRIVER_CAPABILITIES` drops the `display` capability that needs a
+`/dev/nvidia-modeset` a headless host does not have, and `LD_LIBRARY_PATH` puts
+the host driver's `libcuda` ahead of the image's forward-compatibility libraries
+-- CUDA forward compatibility is datacenter-only and fails on GeForce with
+`Error 804`. `assets_path` must point at the RoboTwin repository root, not its
+`assets/` subdirectory.
+
 Prebuilt Docker images, built from `scripts/deployment/Dockerfile.vla-env`, are available for both tracks so you can skip the manual venv build:
 
 - **LIBERO-Pro** image: preconfigured with the LIBERO-Pro simulator stack and Pi0.5 dependencies. [百度网盘](https://pan.baidu.com/s/1HW7AstjCLE_BTScRFOQT2g?pwd=qv7c)
@@ -136,7 +165,17 @@ python -m rollout_runtime.cli serve \
 
 ## Preparing and Running a Campaign
 
-Both LIBERO and RoboCasa use the same two-step flow: `prepare_*_campaign.py` freezes a `manifest.json`/`tool-catalog.json` against a running runtime, then `run_campaign.py` drives the campaign state machine to completion.
+LIBERO, RoboCasa and RoboTwin all use the same two-step flow: `prepare_*_campaign.py` freezes a `manifest.json`/`tool-catalog.json` against a running runtime, then `run_campaign.py` drives the campaign state machine to completion.
+
+RoboTwin differs in two ways that its manifest records explicitly. Its seeds come
+from RoboTwin's curated per-task success-seed list rather than a dense integer
+range -- the environment picks its scene from the seed outright, so a held-out
+block drawn from unsolvable scenes would not be a gate -- and its evidence is
+chunk-granular rather than per-step, because it is the only `final_only` family.
+
+The RoboTwin campaign loop runs end to end on hardware: rollouts, Cluster,
+Diagnose, Stage 2, and the paired same-seed gate, over five candidate rounds to a
+`complete` campaign.
 
 ```bash
 # 1. Start the runtime (see above), then prepare the campaign against it.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -29,6 +29,9 @@ Zetta includes selectively adapted files from the Apache-2.0 licensed
   `zetta/envs/libero/`
 - `rlinf/envs/maniskill/maniskill_env.py` and `rlinf/envs/maniskill/utils.py` →
   `zetta/envs/maniskill/`
+- `rlinf/envs/robotwin/robotwin_env.py` and `rlinf/envs/robotwin/seed_utils.py`,
+  plus the `center_crop_image`/`crop_and_resize` helpers from
+  `rlinf/envs/utils.py` → `zetta/envs/robotwin/`
 - `rlinf/models/embodiment/openpi/` → `zetta/policies/openpi/`
 - `rlinf/models/embodiment/base_policy.py`, the OpenPI-referenced files in
   `rlinf/models/embodiment/modules/`, `rlinf/utils/{nested_dict_process,pytree,rot6d}.py`,

--- a/robots/robotwin/__init__.py
+++ b/robots/robotwin/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Zetta Contributors
+"""RoboTwin 2.0 bimanual runtime used by rollout-evolution campaigns.
+
+Only ``run_rollout`` may import ``rollout_runtime`` (enforced by
+``tests/runtime/test_layering.py``); everything else here is contract-level and
+simulator-free, so it imports cleanly in the minimal test environment.
+"""
+
+from robots.robotwin.action_contract import ARM_SLICES, ARMS, RoboTwinAction
+from robots.robotwin.critic_runtime import extract_robotwin_critic_features
+from robots.robotwin.recovery_controller import RecoveryController
+from robots.robotwin.role1_actor import (
+    ArmAwareRole1,
+    Role1Decision,
+    Role1EpisodeActor,
+)
+from robots.robotwin.role1_agent import ModelBackedRole1, Role1DecisionStore
+from robots.robotwin.tool_catalog import DEFAULT_ROBOTWIN_TOOL_CATALOG
+
+__all__ = [
+    "ARMS",
+    "ARM_SLICES",
+    "DEFAULT_ROBOTWIN_TOOL_CATALOG",
+    "ArmAwareRole1",
+    "ModelBackedRole1",
+    "RecoveryController",
+    "RoboTwinAction",
+    "Role1Decision",
+    "Role1DecisionStore",
+    "Role1EpisodeActor",
+    "extract_robotwin_critic_features",
+]

--- a/robots/robotwin/action_contract.py
+++ b/robots/robotwin/action_contract.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Canonical RoboTwin action contract used by proposal tools.
+
+RoboTwin 2.0 drives an ALOHA-style **bimanual** robot: one action is 14 numbers,
+``[left 6 joints, left gripper, right 6 joints, right gripper]``, and they are
+**absolute joint targets**, not deltas.
+
+Two consequences shape everything in this module.
+
+**Every command must name an arm.** A single-arm primitive copied from a
+single-arm robot has nowhere to say which of the two hands it means, and the
+tool catalog it lands in is content-hashed into a campaign manifest and cannot
+be edited afterwards. So :data:`ARM_SLICES` is the one place the layout is
+written down, and every constructor here takes an explicit ``arm``.
+
+**"Do nothing" is not zero.** Because the targets are absolute, sending zeros to
+the arm you are not commanding does not hold it still -- it commands every joint
+to angle 0 and flings the arm across the table. The idle arm must be filled from
+the *current measured state*, which is why :func:`compose_action` requires the
+observed state and refuses to guess it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+ACTION_DIM = 14
+"""Full bimanual action width."""
+
+JOINTS_PER_ARM = 6
+"""Revolute joints per arm; the 7th slot of each half is the gripper."""
+
+ARM_SLICES: Mapping[str, slice] = {
+    "left": slice(0, 7),
+    "right": slice(7, 14),
+}
+"""The **only** place the bimanual layout is written down.
+
+``[left 6 joints, left gripper, right 6 joints, right gripper]``, matching
+``LeRobotAlohaDataConfig``'s delta mask
+(``[True]*6 + [False] + [True]*6 + [False]``) and RoboTwin's own state vector.
+"""
+
+GRIPPER_OFFSET = JOINTS_PER_ARM
+"""Index of the gripper within one arm's 7-slot half."""
+
+ARMS: tuple[str, ...] = ("left", "right")
+"""The individually addressable arms, in canonical order."""
+
+Arm = Literal["left", "right", "both"]
+
+JOINT_LIMIT = float(np.pi)
+"""Symmetric bound accepted for a joint target, in radians.
+
+Deliberately generous: RoboTwin's per-embodiment URDF limits are narrower and
+are enforced by the simulator's own controller. This bound exists to catch a
+command that is *structurally* wrong -- unnormalised, in the wrong unit, or
+carrying a stray sentinel -- before it reaches the environment actor.
+"""
+
+GRIPPER_RANGE = (0.0, 1.0)
+"""Normalised gripper command range; 0 is fully closed, 1 fully open."""
+
+
+class ArmSelectionError(ValueError):
+    """An action names no arm, or an arm the robot does not have."""
+
+
+def normalize_arm(arm: str) -> str:
+    """Validate and canonicalise an arm selector.
+
+    Args:
+        arm: ``"left"``, ``"right"`` or ``"both"``, in any case.
+
+    Returns:
+        The lower-cased selector.
+
+    Raises:
+        ArmSelectionError: The selector is missing or unknown. There is no
+            default: on a two-armed robot an unnamed arm is a bug, not a
+            preference.
+    """
+    if not arm:
+        raise ArmSelectionError(
+            "RoboTwin is bimanual: every action must name an arm "
+            f"({', '.join(ARMS)}, or 'both')"
+        )
+    selector = str(arm).strip().lower()
+    if selector not in {*ARMS, "both"}:
+        raise ArmSelectionError(
+            f"unknown arm {arm!r}; expected one of {[*ARMS, 'both']}"
+        )
+    return selector
+
+
+def _half(value: Any, *, arm: str) -> np.ndarray:
+    """Validate one arm's 7-slot command half.
+
+    Args:
+        value: A 7-element sequence, ``[6 joint targets, gripper]``.
+        arm: The arm being validated, for the error message.
+
+    Returns:
+        A float64 array of length 7.
+
+    Raises:
+        ValueError: The half is the wrong width, non-finite, or out of range.
+    """
+    array = np.asarray(value, dtype=np.float64).reshape(-1)
+    if array.shape != (JOINTS_PER_ARM + 1,):
+        raise ValueError(
+            f"{arm} arm command must have {JOINTS_PER_ARM + 1} values "
+            f"({JOINTS_PER_ARM} joints + gripper), got shape {array.shape}"
+        )
+    if not np.isfinite(array).all():
+        raise ValueError(f"{arm} arm command contains non-finite values")
+    joints = array[:JOINTS_PER_ARM]
+    if np.any(np.abs(joints) > JOINT_LIMIT):
+        raise ValueError(
+            f"{arm} arm joint targets must lie within +-{JOINT_LIMIT:.4f} rad; "
+            "values outside it usually mean the command is unnormalised or in "
+            "the wrong unit"
+        )
+    gripper = float(array[GRIPPER_OFFSET])
+    low, high = GRIPPER_RANGE
+    if not low <= gripper <= high:
+        raise ValueError(f"{arm} gripper command {gripper} is outside [{low}, {high}]")
+    return array
+
+
+@dataclass(frozen=True, slots=True)
+class RoboTwinAction:
+    """One validated bimanual action.
+
+    Attributes:
+        values: The 14 absolute joint targets.
+        commanded: The arms this action actually commands; the others are
+            holding their measured position. Recorded so an audit can tell a
+            deliberate hold from an accidental one.
+    """
+
+    values: tuple[float, ...]
+    commanded: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Validate the packed action.
+
+        Raises:
+            ValueError: Wrong width, non-finite values, or an unknown arm in
+                ``commanded``.
+        """
+        if len(self.values) != ACTION_DIM:
+            raise ValueError(
+                f"RoboTwin action must have {ACTION_DIM} values, got {len(self.values)}"
+            )
+        if not all(np.isfinite(self.values)):
+            raise ValueError("RoboTwin action contains non-finite values")
+        unknown = sorted(set(self.commanded) - set(ARMS))
+        if unknown:
+            raise ValueError(f"unknown arm(s) in commanded: {unknown}")
+        if not self.commanded:
+            raise ArmSelectionError("an action must command at least one arm")
+
+    def arm_half(self, arm: str) -> tuple[float, ...]:
+        """Return one arm's 7-slot half.
+
+        Args:
+            arm: ``"left"`` or ``"right"``.
+
+        Returns:
+            The 7 values for that arm.
+
+        Raises:
+            ArmSelectionError: ``arm`` is not an individual arm.
+        """
+        selector = normalize_arm(arm)
+        if selector == "both":
+            raise ArmSelectionError("arm_half needs a single arm, not 'both'")
+        return tuple(self.values[ARM_SLICES[selector]])
+
+    def as_array(self) -> np.ndarray:
+        """Return the action as a float32 array.
+
+        Returns:
+            A ``[14]`` float32 array, the layout the env adapter expects.
+        """
+        return np.asarray(self.values, dtype=np.float32)
+
+    def public_dict(self) -> dict[str, Any]:
+        """Return the stable representation used in audit records.
+
+        Returns:
+            A JSON-friendly dict.
+        """
+        return {
+            "schema_version": 1,
+            "contract": "robotwin_bimanual_joint_v1",
+            "commanded_arms": list(self.commanded),
+            "values": [float(value) for value in self.values],
+        }
+
+
+def hold_action(current_state: Sequence[float]) -> RoboTwinAction:
+    """Build the action that keeps both arms exactly where they are.
+
+    The identity command for an absolute-target robot is "repeat the measured
+    state", never a zero vector.
+
+    Args:
+        current_state: The observed 14-dim joint state.
+
+    Returns:
+        An action holding both arms.
+        ``_state_vector`` rejects a state that is not a finite 14-vector.
+    """
+    state = _state_vector(current_state)
+    return RoboTwinAction(values=tuple(state), commanded=ARMS)
+
+
+def compose_action(
+    current_state: Sequence[float],
+    *,
+    left: Sequence[float] | None = None,
+    right: Sequence[float] | None = None,
+) -> RoboTwinAction:
+    """Compose a bimanual action from one or both arm commands.
+
+    Any arm left as ``None`` is filled from ``current_state`` -- it holds its
+    measured position. ``current_state`` is required precisely so that a
+    single-arm command cannot silently zero the other arm.
+
+    Args:
+        current_state: The observed 14-dim joint state.
+        left: The left arm's 7-slot command, or ``None`` to hold.
+        right: The right arm's 7-slot command, or ``None`` to hold.
+
+    Returns:
+        The composed action. ``_half`` and ``_state_vector`` reject a malformed
+        command half or state.
+
+    Raises:
+        ArmSelectionError: Neither arm was commanded.
+    """
+    if left is None and right is None:
+        raise ArmSelectionError(
+            "compose_action must command at least one arm; use hold_action() "
+            "to deliberately hold both"
+        )
+    values = _state_vector(current_state).copy()
+    commanded: list[str] = []
+    for arm, command in (("left", left), ("right", right)):
+        if command is None:
+            continue
+        values[ARM_SLICES[arm]] = _half(command, arm=arm)
+        commanded.append(arm)
+    return RoboTwinAction(values=tuple(values), commanded=tuple(commanded))
+
+
+def action_from_flat(
+    value: Sequence[float] | np.ndarray, *, arm: Arm = "both"
+) -> RoboTwinAction:
+    """Wrap an already-complete 14-vector, recording which arms it owns.
+
+    This is the transport convenience for a policy that emits the full
+    bimanual vector directly (the VLA path); ``arm`` records intent so an audit
+    can still tell whether a single-arm tool produced it.
+
+    Args:
+        value: A 14-element action.
+        arm: The arm(s) this command is claimed to control.
+
+    Returns:
+        The validated action. ``normalize_arm`` rejects an unknown ``arm``.
+
+    Raises:
+        ValueError: The vector is the wrong width or non-finite.
+    """
+    selector = normalize_arm(arm)
+    flat = np.asarray(value, dtype=np.float64).reshape(-1)
+    if flat.shape != (ACTION_DIM,):
+        raise ValueError(
+            f"flat RoboTwin action must have {ACTION_DIM} values, got {flat.shape}"
+        )
+    if not np.isfinite(flat).all():
+        raise ValueError("flat RoboTwin action contains non-finite values")
+    commanded = ARMS if selector == "both" else (selector,)
+    return RoboTwinAction(values=tuple(flat), commanded=commanded)
+
+
+def _state_vector(current_state: Sequence[float]) -> np.ndarray:
+    """Validate an observed joint-state vector.
+
+    Args:
+        current_state: The observed state.
+
+    Returns:
+        A float64 array of length 14.
+
+    Raises:
+        ValueError: The state is the wrong width or non-finite.
+    """
+    state = np.asarray(current_state, dtype=np.float64).reshape(-1)
+    if state.shape != (ACTION_DIM,):
+        raise ValueError(
+            f"RoboTwin state must have {ACTION_DIM} values, got shape {state.shape}"
+        )
+    if not np.isfinite(state).all():
+        raise ValueError("RoboTwin state contains non-finite values")
+    return state

--- a/robots/robotwin/critic_runtime.py
+++ b/robots/robotwin/critic_runtime.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Bimanual, chunk-granular Critic features for audited RoboTwin rollouts.
+
+The evaluator itself is shared (:class:`zetta.evolution.critic.TemporalCritic`);
+what is environment-specific is the feature plane, and RoboTwin's differs from
+every other family here in two ways.
+
+**Evidence is chunk-granular.** RoboTwin is the only ``final_only`` family: one
+``chunk_step`` submits the whole chunk and returns exactly one observation, so
+there are no intermediate frames and a feature can only ever be computed between
+*chunk-final* frames. Every counter below therefore advances once per chunk.
+
+That has a consequence sharp enough to deserve its own field. ``CriticRule``'s
+``dwell_steps`` and ``cooldown_steps`` are unit-less integers, and on LIBERO they
+count **simulator steps**. Here the same number counts **chunks**, so a rule
+copied across families silently changes meaning by a factor of the execute
+horizon -- ``dwell_steps: 10`` is 10 simulator steps on LIBERO and 250 on
+RoboTwin at a horizon of 25. :data:`SIM_STEPS_PER_CHUNK_FEATURE` is published so
+a rule can state the conversion instead of assuming it, and
+:func:`describe_dwell_semantics` produces the note that belongs in a campaign
+manifest.
+
+**Every feature that concerns motion is per-arm.** A single ``eef_motion``
+number cannot say *which hand* stopped moving, and a recovery that does not name
+an arm cannot be executed (see
+:mod:`robots.robotwin.action_contract`). So the plane is mirrored across
+``left`` and ``right``, and :data:`ACTIVE_ARM_FEATURE` reports which arm the
+chunk actually moved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from robots.robotwin.action_contract import ACTION_DIM, ARM_SLICES, ARMS, GRIPPER_OFFSET
+from zetta.evolution.models import CriticPredicate, CriticRule
+
+FEATURE_PREFIX = "robotwin"
+"""Every feature this module publishes is namespaced under it."""
+
+SIM_STEPS_PER_CHUNK_FEATURE = f"{FEATURE_PREFIX}.chunk.sim_steps_per_chunk"
+"""Feature naming how many simulator steps one chunk advanced.
+
+Published so a frozen rule can convert a dwell expressed in simulator steps into
+this family's chunk unit, rather than inheriting a factor-of-horizon error from
+a rule written for a per-step family.
+"""
+
+ACTIVE_ARM_FEATURE = f"{FEATURE_PREFIX}.active_arm"
+"""Feature naming the arm that moved more during the chunk (``left``/``right``/``none``)."""
+
+GRANULARITY_FEATURE = f"{FEATURE_PREFIX}.evidence.granularity"
+"""Constant ``"chunk"``; lets a rule refuse to fire on the wrong evidence unit."""
+
+MOTION_EPSILON = 1e-4
+"""Below this joint-space L2 delta an arm counts as not having moved.
+
+Chosen against RoboTwin's joint targets in radians: an arm genuinely holding
+position reports deltas at the 1e-6 level, while the smallest deliberate motion
+in a 25-step chunk is orders of magnitude above 1e-4.
+"""
+
+
+def critic_rules_from_payload(
+    payload: Sequence[Mapping[str, Any]],
+) -> tuple[CriticRule, ...]:
+    """Rehydrate frozen critic rules from their JSON form.
+
+    Args:
+        payload: The manifest's serialized rules.
+
+    Returns:
+        The rules, with predicates reconstructed.
+    """
+    rules: list[CriticRule] = []
+    for item in payload:
+        value = dict(item)
+        value["evidence_ids"] = tuple(value.get("evidence_ids", ()))
+        value["activation_conditions"] = tuple(
+            CriticPredicate(**dict(condition))
+            for condition in value.get("activation_conditions", ())
+        )
+        rules.append(CriticRule(**value))
+    return tuple(rules)
+
+
+def describe_dwell_semantics(*, execute_horizon: int) -> dict[str, Any]:
+    """Describe what a rule's ``dwell_steps`` means on this family.
+
+    Belongs in the campaign manifest next to the frozen rules: without it a
+    reader cannot tell whether a dwell was written in simulator steps or chunks,
+    and the two differ by ``execute_horizon``.
+
+    Args:
+        execute_horizon: Simulator steps executed per chunk.
+
+    Returns:
+        A JSON-friendly note.
+    """
+    return {
+        "evidence_granularity": "chunk",
+        "dwell_unit": "chunk",
+        "sim_steps_per_chunk": int(execute_horizon),
+        "note": (
+            "RoboTwin is final_only: features exist only at chunk-final frames, "
+            "so dwell_steps and cooldown_steps count chunks. A rule copied from "
+            "a per-step family means "
+            f"{int(execute_horizon)}x more simulator time here."
+        ),
+    }
+
+
+def _arm_state(state: np.ndarray, arm: str) -> np.ndarray:
+    """Slice one arm's 7-slot half out of a joint state.
+
+    Args:
+        state: The 14-dim joint state.
+        arm: ``"left"`` or ``"right"``.
+
+    Returns:
+        The arm's 7 values.
+    """
+    return state[ARM_SLICES[arm]]
+
+
+def _as_state(value: Sequence[float] | None) -> np.ndarray | None:
+    """Coerce an observed state into a validated array.
+
+    Args:
+        value: A 14-dim state, or ``None``.
+
+    Returns:
+        The array, or ``None`` when the input is absent or malformed. A
+        malformed state is treated as missing rather than raising: the Critic is
+        proposal-only and must never be able to abort an episode.
+    """
+    if value is None:
+        return None
+    array = np.asarray(value, dtype=np.float64).reshape(-1)
+    if array.shape != (ACTION_DIM,) or not np.isfinite(array).all():
+        return None
+    return array
+
+
+def robotwin_state_features(state: Sequence[float] | None) -> dict[str, Any]:
+    """The part of the Critic feature plane one state determines by itself.
+
+    ``states.jsonl`` publishes these, and ``lifecycle._observed_critic_features``
+    turns whatever it finds there into the vocabulary Stage2 may bind a critic
+    rule to.  Sharing this function with
+    :func:`extract_robotwin_critic_features` is what keeps the two from drifting:
+    a name Stage2 is offered is by construction a name the runtime Critic can
+    resolve.
+
+    Motion and stall features are deliberately **not** here.  They are chunk
+    deltas, and a campaign records ``states.jsonl`` per simulator step; emitting
+    them from a per-step timeline under the Critic's names would advertise
+    values the Critic never evaluates.
+
+    Args:
+        state: A 14-dim joint state, or ``None``.
+
+    Returns:
+        The state-determined features, under their runtime names.
+    """
+
+    parsed = _as_state(state)
+    features: dict[str, Any] = {
+        f"{FEATURE_PREFIX}.state_available": parsed is not None,
+    }
+    for arm in ARMS:
+        prefix = f"{FEATURE_PREFIX}.arm.{arm}"
+        features[f"{prefix}.gripper"] = (
+            0.0 if parsed is None else float(_arm_state(parsed, arm)[GRIPPER_OFFSET])
+        )
+    return features
+
+
+def extract_robotwin_critic_features(
+    observation: Mapping[str, Any],
+    *,
+    chunk_index: int,
+    executed_horizon: int,
+    reward: float,
+    terminated: bool,
+    truncated: bool,
+    previous_state: Sequence[float] | None = None,
+    stall_counts: Mapping[str, int] | None = None,
+) -> dict[str, Any]:
+    """Expose the audited, chunk-granular Critic feature plane.
+
+    Args:
+        observation: The chunk-final observation; ``state`` must carry the
+            14-dim joint vector.
+        chunk_index: Index of the chunk just executed.
+        executed_horizon: Simulator steps this chunk advanced.
+        reward: The chunk's reward.
+        terminated: Termination flag.
+        truncated: Truncation flag.
+        previous_state: The previous chunk-final joint state, if any.
+        stall_counts: Running per-arm stall counters from the caller, so the
+            feature plane stays a pure function of its inputs.
+
+    Returns:
+        A flat, dotted-name feature dict for
+        :class:`zetta.evolution.critic.TemporalCritic`.
+    """
+    state = _as_state(observation.get("state"))
+    previous = _as_state(previous_state)
+    counters = dict(stall_counts or {})
+
+    features: dict[str, Any] = {
+        GRANULARITY_FEATURE: "chunk",
+        SIM_STEPS_PER_CHUNK_FEATURE: int(executed_horizon),
+        f"{FEATURE_PREFIX}.chunk.index": int(chunk_index),
+        f"{FEATURE_PREFIX}.chunk.reward": float(reward),
+        f"{FEATURE_PREFIX}.chunk.terminated": bool(terminated),
+        f"{FEATURE_PREFIX}.chunk.truncated": bool(truncated),
+        # Shared with states.jsonl so the published vocabulary and the evaluated
+        # plane cannot use two names for one quantity.
+        **robotwin_state_features(state),
+    }
+
+    motions: dict[str, float] = {}
+    for arm in ARMS:
+        prefix = f"{FEATURE_PREFIX}.arm.{arm}"
+        if state is None:
+            features[f"{prefix}.joint_motion"] = 0.0
+            features[f"{prefix}.gripper_motion"] = 0.0
+            features[f"{prefix}.stalled_chunks"] = int(counters.get(arm, 0))
+            motions[arm] = 0.0
+            continue
+        half = _arm_state(state, arm)
+        if previous is None:
+            joint_motion = 0.0
+            gripper_motion = 0.0
+        else:
+            previous_half = _arm_state(previous, arm)
+            joint_motion = float(
+                np.linalg.norm(half[:GRIPPER_OFFSET] - previous_half[:GRIPPER_OFFSET])
+            )
+            gripper_motion = float(
+                abs(half[GRIPPER_OFFSET] - previous_half[GRIPPER_OFFSET])
+            )
+        features[f"{prefix}.joint_motion"] = joint_motion
+        features[f"{prefix}.gripper_motion"] = gripper_motion
+        motions[arm] = joint_motion
+        stalled = int(counters.get(arm, 0))
+        # The very first chunk has no predecessor, so it cannot evidence a
+        # stall; counting it would let a dwell of 1 fire before any motion was
+        # ever possible.
+        if previous is not None and joint_motion < MOTION_EPSILON:
+            stalled += 1
+        elif previous is not None:
+            stalled = 0
+        features[f"{prefix}.stalled_chunks"] = stalled
+
+    if not motions or max(motions.values()) < MOTION_EPSILON:
+        features[ACTIVE_ARM_FEATURE] = "none"
+    else:
+        features[ACTIVE_ARM_FEATURE] = max(motions, key=lambda arm: motions[arm])
+    features[f"{FEATURE_PREFIX}.arm.motion_ratio"] = _motion_ratio(motions)
+    return features
+
+
+def _motion_ratio(motions: Mapping[str, float]) -> float:
+    """Report how one-sided the chunk's motion was.
+
+    Args:
+        motions: Per-arm joint motion magnitudes.
+
+    Returns:
+        ``0.0`` when both arms moved equally (or neither did) and ``1.0`` when
+        only one did. A rule can use this to notice that a task needing both
+        hands is being attempted with one.
+    """
+    values = [float(value) for value in motions.values()]
+    total = sum(values)
+    if total < MOTION_EPSILON:
+        return 0.0
+    return float(abs(values[0] - values[1]) / total) if len(values) == 2 else 0.0
+
+
+def next_stall_counts(features: Mapping[str, Any]) -> dict[str, int]:
+    """Read the per-arm stall counters back out of a feature plane.
+
+    The extractor is a pure function, so the caller carries the counters between
+    chunks; this is the accessor that keeps the key names in one place.
+
+    Args:
+        features: A feature dict from :func:`extract_robotwin_critic_features`.
+
+    Returns:
+        Per-arm stall counts.
+    """
+    return {
+        arm: int(features.get(f"{FEATURE_PREFIX}.arm.{arm}.stalled_chunks", 0))
+        for arm in ARMS
+    }
+
+
+def arm_from_proposal(proposal: Mapping[str, Any]) -> str | None:
+    """Read the arm a critic proposal is about, if it names one.
+
+    A RoboTwin recovery cannot execute without an arm, so a proposal that omits
+    it is not actionable; the caller decides whether that is a rejection or a
+    request for clarification.
+
+    Args:
+        proposal: A critic proposal row.
+
+    Returns:
+        The canonical arm name, or ``None`` when the proposal names none.
+    """
+    from robots.robotwin.action_contract import ArmSelectionError, normalize_arm
+
+    candidate = proposal.get("arm")
+    if candidate is None:
+        details = proposal.get("details")
+        if isinstance(details, Mapping):
+            candidate = details.get("arm")
+    if candidate is None:
+        return None
+    try:
+        return normalize_arm(str(candidate))
+    except ArmSelectionError:
+        return None

--- a/robots/robotwin/recovery_controller.py
+++ b/robots/robotwin/recovery_controller.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Episode-local, append-only execution state for frozen RoboTwin recoveries.
+
+The controller does not restore simulator state after a process crash. It keeps
+a selected recovery active across multiple online chunks so a fresh VLA proposal
+cannot silently erase it after one tool call.
+
+Two things differ from a single-arm controller, and both come from the same
+place -- RoboTwin has two hands and absolute joint targets:
+
+**A recovery step that drives an arm must name it, and the name is checked at
+activation.** A step whose tool is arm-scoped (:attr:`ToolSpec.arm_scoped`) but
+carries no ``arm`` is not executable, and discovering that halfway through a
+recovery means the episode has already been perturbed. So the whole program is
+validated before the first step runs.
+
+**The arm actually driven is verified against the frozen step.** The Actor
+reports which arm it drove; if it does not match the frozen program, the step is
+rejected rather than counted. Without this, a recovery frozen against the left
+arm could be satisfied by moving the right one and the audit trail would still
+read as compliant.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from robots.robotwin.action_contract import ArmSelectionError, normalize_arm
+from robots.robotwin.tool_catalog import DEFAULT_ROBOTWIN_TOOL_CATALOG, ToolCatalog
+from zetta.evolution.jsonio import canonical_sha256
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryExecutionState:
+    """One recovery's episode-local progress.
+
+    Attributes:
+        execution_id: Unique id for this activation.
+        bundle_sha256: The candidate bundle this recovery was frozen in.
+        recovery_id: The frozen recovery's id.
+        trigger_rule_ids: The critic rules that activated it.
+        current_step_index: Index of the step awaiting execution.
+        status: ``"active"`` or ``"completed"``.
+        started_at_environment_step: Env step at activation.
+        last_environment_step: Env step of the most recent advance.
+        completed_tool_invocations: How many steps have completed.
+        arm_program: The frozen per-step arm sequence, ``None`` where a step is
+            not arm-scoped.
+    """
+
+    execution_id: str
+    bundle_sha256: str
+    recovery_id: str
+    trigger_rule_ids: tuple[str, ...]
+    current_step_index: int
+    status: str
+    started_at_environment_step: int
+    last_environment_step: int
+    completed_tool_invocations: int
+    arm_program: tuple[str | None, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the JSON-friendly form.
+
+        Returns:
+            A plain dict.
+        """
+        return asdict(self)
+
+
+class RecoveryContractError(ValueError):
+    """A frozen recovery cannot be executed as written."""
+
+
+def validate_arm_program(
+    steps: Sequence[Mapping[str, Any]],
+    *,
+    catalog: ToolCatalog = DEFAULT_ROBOTWIN_TOOL_CATALOG,
+) -> tuple[str | None, ...]:
+    """Resolve and validate the per-step arm sequence of a recovery.
+
+    Args:
+        steps: The frozen recovery steps.
+        catalog: Catalog the step tools are resolved against.
+
+    Returns:
+        One entry per step: the canonical arm name, or ``None`` when the step's
+        tool is not arm-scoped.
+
+    Raises:
+        RecoveryContractError: A step names an unknown tool, an arm-scoped step
+            omits its arm, a non-arm-scoped step carries one, or the arm is not
+            a valid selector.
+    """
+    program: list[str | None] = []
+    for index, step in enumerate(steps):
+        tool = str(step.get("tool", "")).strip()
+        if not tool:
+            raise RecoveryContractError(f"recovery step {index} names no tool")
+        try:
+            spec = catalog.get(tool)
+        except KeyError as exc:
+            raise RecoveryContractError(
+                f"recovery step {index} names tool {tool!r}, which this catalog "
+                "does not declare"
+            ) from exc
+        arguments = step.get("arguments")
+        arguments = dict(arguments) if isinstance(arguments, Mapping) else {}
+        if "arm" not in arguments and step.get("arm") is not None:
+            arguments["arm"] = step["arm"]
+        try:
+            program.append(spec.validate_arguments(arguments))
+        except (ValueError, ArmSelectionError) as exc:
+            raise RecoveryContractError(
+                f"recovery step {index} ({tool}): {exc}"
+            ) from exc
+    return tuple(program)
+
+
+class RecoveryController:
+    """Select one frozen recovery and advance its ordered steps exactly once."""
+
+    def __init__(
+        self,
+        *,
+        bundle_sha256: str,
+        audit_path: str | Path,
+        catalog: ToolCatalog = DEFAULT_ROBOTWIN_TOOL_CATALOG,
+    ) -> None:
+        """Initialize the controller.
+
+        Args:
+            bundle_sha256: The active candidate bundle.
+            audit_path: JSONL file the controller appends events to.
+            catalog: Catalog used to resolve step tools.
+        """
+        self.bundle_sha256 = bundle_sha256
+        self.audit_path = Path(audit_path)
+        self.audit_path.parent.mkdir(parents=True, exist_ok=True)
+        self.catalog = catalog
+        self._rule: dict[str, Any] | None = None
+        self.state: RecoveryExecutionState | None = None
+
+    @property
+    def active(self) -> bool:
+        """Whether a recovery is mid-execution.
+
+        Returns:
+            ``True`` while steps remain.
+        """
+        return self.state is not None and self.state.status == "active"
+
+    def _append(self, event: str, **payload: Any) -> None:
+        """Append one durable audit row.
+
+        Args:
+            event: Event name.
+            **payload: Event fields.
+        """
+        row = {
+            "event_id": f"recovery-event-{uuid.uuid4().hex}",
+            "event": event,
+            "bundle_sha256": self.bundle_sha256,
+            **payload,
+        }
+        with self.audit_path.open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+
+    def activate(
+        self,
+        *,
+        critic_proposals: Sequence[Mapping[str, Any]],
+        recovery_rules: Sequence[Mapping[str, Any]],
+        environment_step: int,
+    ) -> bool:
+        """Activate the first matching frozen recovery; never reset active work.
+
+        Args:
+            critic_proposals: The Critic's proposals for this boundary.
+            recovery_rules: The frozen recoveries in the active bundle.
+            environment_step: The current env step.
+
+        Returns:
+            ``True`` when a recovery was activated.
+
+        Raises:
+            RecoveryContractError: The selected recovery has no steps, no id, or
+                an unexecutable arm program.
+        """
+        if self.active:
+            return False
+        triggers = {
+            str(row.get("rule_id", ""))
+            for row in critic_proposals
+            if row.get("rule_id")
+        }
+        matches = [
+            dict(rule)
+            for rule in recovery_rules
+            if triggers.intersection(
+                str(value) for value in rule.get("trigger_rule_ids", ())
+            )
+        ]
+        if not matches:
+            return False
+        # Candidate validation guarantees stable unique ids; sorting makes the
+        # Actor-visible choice deterministic when one Critic is linked to more
+        # than one retained parent recovery.
+        matches.sort(key=lambda row: str(row.get("recovery_id", "")))
+        selected = matches[0]
+        steps = selected.get("steps")
+        if (
+            not isinstance(steps, Sequence)
+            or isinstance(steps, (str, bytes, bytearray))
+            or not steps
+        ):
+            raise RecoveryContractError("activated recovery has no executable steps")
+        recovery_id = str(selected.get("recovery_id", ""))
+        if not recovery_id:
+            raise RecoveryContractError("activated recovery has no recovery_id")
+        selected["steps"] = [dict(step) for step in steps]
+        # Validate the whole arm program up front: finding an unexecutable step
+        # halfway through means the episode has already been perturbed by the
+        # steps that did run.
+        arm_program = validate_arm_program(selected["steps"], catalog=self.catalog)
+        self._rule = selected
+        self.state = RecoveryExecutionState(
+            execution_id=f"recovery-{uuid.uuid4().hex}",
+            bundle_sha256=self.bundle_sha256,
+            recovery_id=recovery_id,
+            trigger_rule_ids=tuple(sorted(triggers)),
+            current_step_index=0,
+            status="active",
+            started_at_environment_step=environment_step,
+            last_environment_step=environment_step,
+            completed_tool_invocations=0,
+            arm_program=arm_program,
+        )
+        self._append(
+            "activated",
+            state=self.state.as_dict(),
+            recovery_rule_sha256=canonical_sha256(selected),
+        )
+        return True
+
+    def context(self) -> dict[str, Any] | None:
+        """Describe the step awaiting execution.
+
+        Returns:
+            The Actor-visible context, or ``None`` when no recovery is active.
+        """
+        if not self.active or self._rule is None or self.state is None:
+            return None
+        steps = self._rule["steps"]
+        index = self.state.current_step_index
+        return {
+            "execution": self.state.as_dict(),
+            "recovery_id": self.state.recovery_id,
+            "title": self._rule.get("title"),
+            "precondition": self._rule.get("precondition"),
+            "current_step": dict(steps[index]),
+            "current_step_arm": self.state.arm_program[index]
+            if index < len(self.state.arm_program)
+            else None,
+            "remaining_steps": len(steps) - index,
+            "safety_constraints": list(self._rule.get("safety_constraints", ())),
+            "stop_condition": self._rule.get("stop_condition"),
+            "fallback": self._rule.get("fallback"),
+        }
+
+    def complete_current_step(
+        self,
+        *,
+        selected_tool: str | None,
+        environment_step: int,
+        executed_horizon: int,
+        executed_arm: str | None = None,
+        no_op_verified: bool = False,
+    ) -> RecoveryExecutionState:
+        """Record that the current step executed, and advance.
+
+        Args:
+            selected_tool: The tool the Actor actually invoked.
+            environment_step: The env step after execution.
+            executed_horizon: Simulator steps the action advanced.
+            executed_arm: The arm the Actor actually drove, when the step is
+                arm-scoped.
+            no_op_verified: Whether a zero-horizon step was a verified no-op.
+
+        Returns:
+            The updated execution state.
+
+        Raises:
+            ValueError: No recovery is active, or the step produced no action.
+            RecoveryContractError: The executed tool or arm does not match the
+                frozen program.
+        """
+        if not self.active or self._rule is None or self.state is None:
+            raise ValueError("cannot advance an inactive recovery")
+        index = self.state.current_step_index
+        step = self._rule["steps"][index]
+        required_tool = str(step.get("tool", ""))
+        if selected_tool != required_tool:
+            raise RecoveryContractError(
+                "Actor did not execute the frozen recovery step tool"
+            )
+        required_arm = (
+            self.state.arm_program[index]
+            if index < len(self.state.arm_program)
+            else None
+        )
+        if required_arm is not None:
+            if executed_arm is None:
+                raise RecoveryContractError(
+                    f"frozen recovery step {index} drives the {required_arm} arm, "
+                    "but the Actor reported no arm"
+                )
+            if normalize_arm(executed_arm) != required_arm:
+                raise RecoveryContractError(
+                    f"frozen recovery step {index} drives the {required_arm} arm, "
+                    f"but the Actor drove {executed_arm!r}"
+                )
+        elif executed_arm is not None:
+            raise RecoveryContractError(
+                f"frozen recovery step {index} is not arm-scoped, but the Actor "
+                f"reported driving {executed_arm!r}"
+            )
+        if executed_horizon < 1 and not bool(no_op_verified):
+            raise ValueError("recovery step produced no environment action")
+        next_index = index + 1
+        complete = next_index >= len(self._rule["steps"])
+        prior = self.state
+        self.state = RecoveryExecutionState(
+            execution_id=prior.execution_id,
+            bundle_sha256=prior.bundle_sha256,
+            recovery_id=prior.recovery_id,
+            trigger_rule_ids=prior.trigger_rule_ids,
+            current_step_index=(index if complete else next_index),
+            status="completed" if complete else "active",
+            started_at_environment_step=prior.started_at_environment_step,
+            last_environment_step=environment_step,
+            completed_tool_invocations=prior.completed_tool_invocations + 1,
+            arm_program=prior.arm_program,
+        )
+        self._append(
+            "completed" if complete else "step_advanced",
+            prior_state=prior.as_dict(),
+            state=self.state.as_dict(),
+            selected_tool=selected_tool,
+            executed_arm=executed_arm,
+            executed_horizon=executed_horizon,
+            no_op_verified=bool(no_op_verified),
+        )
+        if complete:
+            self._rule = None
+        return self.state
+
+
+__all__ = [
+    "RecoveryContractError",
+    "RecoveryController",
+    "RecoveryExecutionState",
+    "validate_arm_program",
+]

--- a/robots/robotwin/role1_actor.py
+++ b/robots/robotwin/role1_actor.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Single-writer Actor that turns a persisted Role1 decision into an action chunk.
+
+The role boundaries the campaign protocol fixes are load-bearing here:
+
+- the **Critic** reads temporal evidence and may only *propose* a recovery;
+- **Role1** accepts or rejects that proposal and is the sole high-level decision
+  authority;
+- the **recovery actor** executes only an accepted, bounded recovery program;
+- only the environment actor may write simulator actions.
+
+This module is that last one. Every tool that can influence it is declared
+``proposal_only`` in the catalog: the frozen recovery step says *what* should
+happen to *which arm*, and the Actor is what composes the actual joint targets.
+It deliberately holds no environment client, so a failed decision cannot
+partially mutate the simulator.
+
+The bimanual contract does real work at this boundary. A recovery step like
+"close the right gripper" is not a 7-number command -- RoboTwin consumes 14
+absolute joint targets, so the Actor must also decide what the *left* arm does,
+and the only correct answer is "hold its measured pose". That is why every
+action here is built through :func:`~robots.robotwin.action_contract.compose_action`
+with the observed state, and never by zero-filling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import numpy as np
+
+from robots.robotwin.action_contract import (
+    ACTION_DIM,
+    ARM_SLICES,
+    GRIPPER_OFFSET,
+    GRIPPER_RANGE,
+    ArmSelectionError,
+    RoboTwinAction,
+    action_from_flat,
+    compose_action,
+    hold_action,
+    normalize_arm,
+)
+from robots.robotwin.critic_runtime import arm_from_proposal
+from robots.robotwin.recovery_controller import (
+    RecoveryContractError,
+    RecoveryController,
+)
+from robots.robotwin.tool_bindings import TaskToolBinding
+
+VLA_TOOL = "robotwin.vla.pi05"
+"""The action source when no recovery is running."""
+
+HOLD_TOOL = "robotwin.control.hold_arm"
+"""Frozen step that pins one arm at its measured pose."""
+
+GRIPPER_TOOL = "robotwin.gripper.set"
+"""Frozen step that drives one arm's gripper."""
+
+ROLE1_SYSTEM_CONTRACT = """You are the sole high-level Role1 decision authority
+for one event in a bimanual robot episode. Tool outputs are proposals only. A
+critic may only recommend rejecting the current action; it cannot execute,
+replace, recover, switch, or terminate. Select no default tool and make no
+implicit fallback. Use only the event's allowed stages and tools. Do not
+request, infer, or mention experiment identity, random generators, or future
+rollout order. Return exactly one JSON object and no Markdown or surrounding
+text.
+
+Two facts about this robot constrain every decision you make.
+
+The robot has two arms. Every action is 14 absolute joint targets, laid out as
+left arm (6 joints, 1 gripper) then right arm (6 joints, 1 gripper). A decision
+that drives an arm must name it: "left" or "right". A proposal that names no arm
+is not executable and must be rejected rather than resolved to a default. There
+is no default hand.
+
+The targets are absolute, not deltas. Commanding an arm to hold position means
+repeating its measured joint values; a zero vector commands every joint to angle
+zero and throws the arm across the workspace. When you accept a recovery that
+drives one arm, the other arm holds -- that is a decision you are making, not a
+side effect.
+
+Evidence is chunk-granular. This environment submits a whole action chunk and
+returns only the final frame, so you never see intermediate steps and a critic's
+dwell counts chunk boundaries, not simulator steps. Do not reason about
+per-step motion you were not shown.
+"""
+"""The system contract for a model-backed Role1 on this family.
+
+Frozen into the campaign's prompt contract, so its hash is part of what a
+preregistration commits to.
+"""
+
+
+EXECUTABLE_STEP_TOOLS = frozenset({HOLD_TOOL, GRIPPER_TOOL})
+"""The frozen step tools this Actor knows how to turn into joint targets.
+
+Deliberately small. A step naming anything else is refused rather than
+approximated: silently substituting a different motion for an unimplemented one
+would make the audit trail claim a recovery ran that never did.
+"""
+
+
+class Role1ActorError(RuntimeError):
+    """The Actor cannot honour a decision or a frozen step."""
+
+
+@dataclass(frozen=True, slots=True)
+class Role1Decision:
+    """Role1's verdict on one Critic proposal.
+
+    Attributes:
+        accepted: Whether the proposal is accepted.
+        reason: Why, recorded verbatim in the audit trail.
+        proposal_id: The proposal this verdict answers.
+        arm: The arm the verdict concerns, when the proposal named one.
+    """
+
+    accepted: bool
+    reason: str
+    proposal_id: str | None = None
+    arm: str | None = None
+
+    def public_dict(self) -> dict[str, Any]:
+        """Return the JSON-friendly form.
+
+        Returns:
+            A plain dict.
+        """
+        return {
+            "accepted": bool(self.accepted),
+            "reason": self.reason,
+            "proposal_id": self.proposal_id,
+            "arm": self.arm,
+        }
+
+
+class Role1Decider(Protocol):
+    """The seam where a model-backed Role1 plugs in.
+
+    Kept narrow on purpose: the Actor needs a verdict, not a conversation, and
+    an implementation that reaches the simulator would break the single-writer
+    property this module exists to hold.
+    """
+
+    def decide(
+        self,
+        *,
+        task: str,
+        chunk_index: int,
+        features: Mapping[str, Any],
+        proposals: Sequence[Mapping[str, Any]],
+    ) -> Role1Decision:
+        """Accept or reject the leading Critic proposal.
+
+        Args:
+            task: The task under evaluation.
+            chunk_index: Index of the chunk boundary being decided.
+            features: The Critic feature plane for this boundary.
+            proposals: The Critic's proposals, most significant first.
+
+        Returns:
+            The verdict.
+        """
+        ...
+
+
+class ArmAwareRole1(Role1Decider):
+    """Reference Role1: accepts only proposals that are actually executable.
+
+    This is not a stand-in for a model-backed Role1 -- it is the floor beneath
+    one. A RoboTwin recovery cannot run without an arm, so a proposal that names
+    none is rejected here regardless of how convincing its evidence is, and a
+    model-backed decider inherits the same requirement by being asked for the
+    same verdict shape.
+    """
+
+    def __init__(self, *, require_arm: bool = True) -> None:
+        """Configure the reference decider.
+
+        Args:
+            require_arm: Whether a proposal must name an arm to be accepted.
+        """
+        self.require_arm = require_arm
+
+    def decide(
+        self,
+        *,
+        task: str,
+        chunk_index: int,
+        features: Mapping[str, Any],
+        proposals: Sequence[Mapping[str, Any]],
+    ) -> Role1Decision:
+        """Accept the first proposal that names an arm.
+
+        Args:
+            task: The task under evaluation.
+            chunk_index: The chunk boundary index.
+            features: The Critic feature plane.
+            proposals: The Critic's proposals.
+
+        Returns:
+            The verdict.
+        """
+        if not proposals:
+            return Role1Decision(accepted=False, reason="no critic proposal")
+        leading = proposals[0]
+        proposal_id = str(leading.get("rule_id") or leading.get("proposal_id") or "")
+        arm = arm_from_proposal(leading)
+        if self.require_arm and arm is None:
+            return Role1Decision(
+                accepted=False,
+                reason=(
+                    "proposal names no arm; a RoboTwin recovery cannot be "
+                    "executed without one"
+                ),
+                proposal_id=proposal_id or None,
+            )
+        return Role1Decision(
+            accepted=True,
+            reason=str(leading.get("proposal") or leading.get("reason") or "accepted"),
+            proposal_id=proposal_id or None,
+            arm=arm,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Role1ActorResult:
+    """What the Actor decided to execute at one chunk boundary.
+
+    Attributes:
+        actions: The ``[chunk, 14]`` action block to submit.
+        source: ``"vla"``, ``"recovery"`` or ``"hold"``.
+        commanded_arms: The arms the action actually commands.
+        selected_tool: The frozen step tool executed, when in a recovery.
+        decision: Role1's verdict, when one was taken.
+        terminate: Whether the episode should stop.
+        termination_reason: Why, when terminating.
+    """
+
+    actions: tuple[tuple[float, ...], ...]
+    source: str
+    commanded_arms: tuple[str, ...]
+    selected_tool: str | None = None
+    decision: Role1Decision | None = None
+    terminate: bool = False
+    termination_reason: str = ""
+
+    def as_array(self) -> np.ndarray:
+        """Return the action block as float32.
+
+        Returns:
+            A ``[chunk, 14]`` array.
+        """
+        return np.asarray(self.actions, dtype=np.float32)
+
+
+def _state_from_observation(observation: Mapping[str, Any]) -> np.ndarray:
+    """Read the 14-dim joint state out of an observation.
+
+    Args:
+        observation: The chunk-final observation.
+
+    Returns:
+        The state as a float64 array.
+
+    Raises:
+        Role1ActorError: The observation carries no usable state. The Actor
+            cannot compose a hold without it, and guessing would be exactly the
+            zero-fill mistake the action contract exists to prevent.
+    """
+    state = observation.get("state")
+    if state is None:
+        raise Role1ActorError("observation carries no joint state")
+    array = np.asarray(state, dtype=np.float64).reshape(-1)
+    if array.shape != (ACTION_DIM,) or not np.isfinite(array).all():
+        raise Role1ActorError(
+            f"observation state must be {ACTION_DIM} finite values, got shape "
+            f"{array.shape}"
+        )
+    return array
+
+
+def _gripper_half(state: np.ndarray, arm: str, opening: float) -> list[float]:
+    """Build one arm's command that only moves the gripper.
+
+    The six joints repeat their measured values, so the arm does not drift while
+    the gripper closes.
+
+    Args:
+        state: The observed 14-dim state.
+        arm: The arm to command.
+        opening: Normalised gripper opening.
+
+    Returns:
+        The arm's 7-slot command.
+
+    Raises:
+        Role1ActorError: The opening is outside the contract's range.
+    """
+    low, high = GRIPPER_RANGE
+    if not low <= float(opening) <= high:
+        raise Role1ActorError(f"gripper opening {opening} is outside [{low}, {high}]")
+    half = list(state[ARM_SLICES[arm]])
+    half[GRIPPER_OFFSET] = float(opening)
+    return half
+
+
+def action_for_recovery_step(
+    step: Mapping[str, Any],
+    *,
+    arm: str | None,
+    observation: Mapping[str, Any],
+) -> RoboTwinAction:
+    """Compose the joint targets one frozen recovery step calls for.
+
+    Args:
+        step: The frozen step.
+        arm: The step's validated arm, or ``None`` when it is not arm-scoped.
+        observation: The chunk-final observation.
+
+    Returns:
+        The composed action.
+
+    Raises:
+        Role1ActorError: The step names a tool this Actor cannot execute, or its
+            arguments are unusable.
+    """
+    tool = str(step.get("tool", ""))
+    if tool not in EXECUTABLE_STEP_TOOLS:
+        raise Role1ActorError(
+            f"frozen recovery step names {tool!r}, which this Actor cannot turn "
+            f"into joint targets; executable steps are {sorted(EXECUTABLE_STEP_TOOLS)}"
+        )
+    state = _state_from_observation(observation)
+    if arm is None:
+        raise Role1ActorError(f"{tool} is arm-scoped but the step resolved no arm")
+    selector = normalize_arm(arm)
+    if selector == "both":
+        raise Role1ActorError(f"{tool} must name a single arm, not 'both'")
+
+    if tool == HOLD_TOOL:
+        # Holding one arm still means sending a full 14-vector: the other arm
+        # keeps its measured pose too, which is exactly what compose_action does.
+        return compose_action(state, **{selector: list(state[ARM_SLICES[selector]])})
+
+    arguments = step.get("arguments")
+    arguments = dict(arguments) if isinstance(arguments, Mapping) else {}
+    if "opening" not in arguments:
+        raise Role1ActorError(f"{GRIPPER_TOOL} step requires an 'opening' argument")
+    half = _gripper_half(state, selector, float(arguments["opening"]))
+    return compose_action(state, **{selector: half})
+
+
+class Role1EpisodeActor:
+    """Resolve one action boundary through proposal-only tools and Role1."""
+
+    def __init__(
+        self,
+        *,
+        decider: Role1Decider,
+        binding: TaskToolBinding,
+        recovery: RecoveryController | None = None,
+        maximum_rejections_without_action: int = 4,
+    ) -> None:
+        """Initialize the Actor.
+
+        Args:
+            decider: Role1's verdict source.
+            binding: The task's frozen tool binding.
+            recovery: The recovery controller, when a bundle is active.
+            maximum_rejections_without_action: Bound on consecutive boundaries
+                resolved without executing anything.
+
+        Raises:
+            ValueError: The bound is not positive.
+        """
+        if maximum_rejections_without_action < 1:
+            raise ValueError("maximum_rejections_without_action must be positive")
+        self.decider = decider
+        self.binding = binding
+        self.recovery = recovery
+        self.maximum_rejections_without_action = maximum_rejections_without_action
+        self._consecutive_holds = 0
+
+    def decide_action(
+        self,
+        *,
+        task: str,
+        chunk_index: int,
+        observation: Mapping[str, Any],
+        vla_actions: Sequence[Sequence[float]],
+        features: Mapping[str, Any] | None = None,
+        critic_proposals: Sequence[Mapping[str, Any]] = (),
+        recovery_rules: Sequence[Mapping[str, Any]] = (),
+        environment_step: int = 0,
+    ) -> Role1ActorResult:
+        """Resolve one chunk boundary into an action block.
+
+        Args:
+            task: The task; must match the frozen binding.
+            chunk_index: Index of this chunk boundary.
+            observation: The chunk-final observation.
+            vla_actions: The policy's ``[chunk, 14]`` proposal.
+            features: The Critic feature plane for this boundary.
+            critic_proposals: The Critic's proposals.
+            recovery_rules: The frozen recoveries in the active bundle.
+            environment_step: The current env step, for the recovery audit.
+
+        Returns:
+            The resolved action block and its provenance.
+
+        Raises:
+            Role1ActorError: The task does not match the binding, or the VLA
+                proposal is unusable and no recovery covers the boundary.
+        """
+        if task != self.binding.task:
+            raise Role1ActorError("Actor task does not match its frozen tool binding")
+
+        # 1. An already-running recovery owns the boundary: a fresh VLA proposal
+        #    must not be able to erase a bounded program mid-flight.
+        if self.recovery is not None and self.recovery.active:
+            return self._execute_recovery_step(observation)
+
+        # 2. Otherwise Role1 rules on the Critic's proposals.
+        decision: Role1Decision | None = None
+        if critic_proposals:
+            decision = self.decider.decide(
+                task=task,
+                chunk_index=chunk_index,
+                features=dict(features or {}),
+                proposals=list(critic_proposals),
+            )
+            if decision.accepted and self.recovery is not None:
+                try:
+                    activated = self.recovery.activate(
+                        critic_proposals=critic_proposals,
+                        recovery_rules=recovery_rules,
+                        environment_step=environment_step,
+                    )
+                except RecoveryContractError as exc:
+                    # An unexecutable frozen program is a candidate defect, not
+                    # a reason to stall the episode: fall back to the policy and
+                    # let the audit record why.
+                    return self._vla_result(
+                        vla_actions,
+                        decision=Role1Decision(
+                            accepted=False,
+                            reason=f"recovery rejected: {exc}",
+                            proposal_id=decision.proposal_id,
+                            arm=decision.arm,
+                        ),
+                    )
+                if activated:
+                    return self._execute_recovery_step(observation, decision=decision)
+
+        # 3. No accepted, executable recovery: run the policy's own chunk.
+        return self._vla_result(vla_actions, decision=decision)
+
+    def _execute_recovery_step(
+        self,
+        observation: Mapping[str, Any],
+        *,
+        decision: Role1Decision | None = None,
+    ) -> Role1ActorResult:
+        """Compose the action for the recovery step awaiting execution.
+
+        Args:
+            observation: The chunk-final observation.
+            decision: The verdict that activated the recovery, if this is its
+                first step.
+
+        Returns:
+            The action block for the current step.
+
+        Raises:
+            Role1ActorError: No recovery context is available.
+        """
+        if self.recovery is None:
+            raise Role1ActorError("no recovery controller is attached")
+        context = self.recovery.context()
+        if context is None:
+            raise Role1ActorError("recovery is active but exposed no context")
+        step = context["current_step"]
+        arm = context.get("current_step_arm")
+        action = action_for_recovery_step(step, arm=arm, observation=observation)
+        self._consecutive_holds = 0
+        return Role1ActorResult(
+            actions=(tuple(action.values),),
+            source="recovery",
+            commanded_arms=action.commanded,
+            selected_tool=str(step.get("tool", "")),
+            decision=decision,
+        )
+
+    def _vla_result(
+        self,
+        vla_actions: Sequence[Sequence[float]],
+        *,
+        decision: Role1Decision | None,
+    ) -> Role1ActorResult:
+        """Pass the policy's chunk through, recording its arm provenance.
+
+        Args:
+            vla_actions: The policy's ``[chunk, 14]`` proposal.
+            decision: Role1's verdict, when one was taken.
+
+        Returns:
+            The action block.
+
+        Raises:
+            Role1ActorError: The proposal is empty or malformed.
+        """
+        if not len(vla_actions):
+            raise Role1ActorError("policy returned an empty action chunk")
+        try:
+            rows = [action_from_flat(row) for row in vla_actions]
+        except (ValueError, ArmSelectionError) as exc:
+            raise Role1ActorError(f"policy chunk is not a valid action: {exc}") from exc
+        self._consecutive_holds = 0
+        return Role1ActorResult(
+            actions=tuple(tuple(row.values) for row in rows),
+            source="vla",
+            commanded_arms=rows[0].commanded,
+            selected_tool=VLA_TOOL,
+            decision=decision,
+        )
+
+    def hold(self, observation: Mapping[str, Any]) -> Role1ActorResult:
+        """Emit an explicit both-arm hold, bounded by the no-action limit.
+
+        Args:
+            observation: The chunk-final observation.
+
+        Returns:
+            The hold action, terminating once the bound is reached.
+        """
+        action = hold_action(_state_from_observation(observation))
+        self._consecutive_holds += 1
+        exhausted = self._consecutive_holds >= self.maximum_rejections_without_action
+        return Role1ActorResult(
+            actions=(tuple(action.values),),
+            source="hold",
+            commanded_arms=action.commanded,
+            terminate=exhausted,
+            termination_reason=(
+                f"no action taken for {self._consecutive_holds} consecutive boundaries"
+                if exhausted
+                else ""
+            ),
+        )
+
+
+__all__ = [
+    "ROLE1_SYSTEM_CONTRACT",
+    "ArmAwareRole1",
+    "Role1ActorError",
+    "Role1ActorResult",
+    "Role1Decider",
+    "Role1Decision",
+    "Role1EpisodeActor",
+    "action_for_recovery_step",
+]

--- a/robots/robotwin/role1_agent.py
+++ b/robots/robotwin/role1_agent.py
@@ -1,0 +1,622 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Model-backed Role1 for RoboTwin: one audited decision per chunk boundary.
+
+The protocol's role split is what this file has to protect. The Critic proposes,
+Role1 rules, and only the Actor writes actions -- so this module obtains a
+verdict and persists it, and it never chooses a tool, never repairs invalid
+model output, and never touches the simulator.
+
+Three checks are specific to a bimanual robot and are the reason this is not a
+generic adapter:
+
+1. **The model may not invent a hand.** A verdict must echo the arm it is ruling
+   on, and that arm must be the one the Critic's evidence concerned. Letting the
+   model redirect a left-arm observation into a right-arm recovery would produce
+   an audit trail that reads as compliant while authorising something the
+   evidence never supported.
+2. **A proposal that names no arm cannot be accepted.** A RoboTwin recovery is
+   not executable without one, so accepting it would promise an action nobody
+   can take.
+3. **The payload is chunk-granular and says so.** This family sees one frame per
+   chunk, so a verdict must not be asked to reason about per-step motion it was
+   never shown.
+
+Seed blindness is enforced on the way out: the payload must carry no seed, RNG
+or future-schedule metadata, because a Role1 that can see the schedule is no
+longer making an online decision.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from robots.robotwin.action_contract import ARMS, ArmSelectionError, normalize_arm
+from robots.robotwin.critic_runtime import GRANULARITY_FEATURE, arm_from_proposal
+from robots.robotwin.role1_actor import ROLE1_SYSTEM_CONTRACT, Role1Decision
+from zetta.evolution.jsonio import atomic_write_json, canonical_sha256
+
+_FORBIDDEN_KEY_TOKENS = frozenset({"seed", "rng", "master_seed", "policy_rng"})
+"""Key names that would leak experiment identity into an online decision."""
+
+_TOKEN_SPLIT = re.compile(r"[^a-z0-9]+")
+"""Split an identifier into lower-case tokens."""
+
+_FORBIDDEN_TEXT = re.compile(r"\b(?:seed|rng)\s*[:=]\s*\d+", re.IGNORECASE)
+"""Free text that embeds a concrete seed value."""
+
+VALID_DISPOSITIONS = ("accept", "reject")
+"""The verdicts Role1 may return for a Critic proposal."""
+
+
+class Role1ContractError(ValueError):
+    """The model's output violates the frozen Role1 contract."""
+
+
+class Role1ModelError(RuntimeError):
+    """The model could not be reached, or returned nothing usable."""
+
+
+def _tokens(value: str) -> set[str]:
+    """Split an identifier into lower-case tokens.
+
+    Args:
+        value: The identifier.
+
+    Returns:
+        Its tokens.
+    """
+    return {token for token in _TOKEN_SPLIT.split(value.lower()) if token}
+
+
+def assert_seed_blind(value: Any, *, path: str = "input") -> None:
+    """Reject explicit experiment identity and future-schedule leakage.
+
+    Args:
+        value: The payload to inspect, recursively.
+        path: Location prefix used in the error message.
+
+    Raises:
+        Role1ContractError: The payload carries seed/RNG metadata, a future
+            schedule, or free text embedding a seed value.
+    """
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            lowered = str(key).lower()
+            tokens = _tokens(str(key))
+            if lowered in _FORBIDDEN_KEY_TOKENS or tokens & {"seed", "rng"}:
+                raise Role1ContractError(
+                    f"seed or RNG metadata is forbidden at {path}.{key}"
+                )
+            if "future" in tokens and "schedule" in tokens:
+                raise Role1ContractError(
+                    f"future schedule is forbidden at {path}.{key}"
+                )
+            assert_seed_blind(item, path=f"{path}.{key}")
+    elif isinstance(value, list | tuple):
+        for index, item in enumerate(value):
+            assert_seed_blind(item, path=f"{path}[{index}]")
+    elif isinstance(value, str) and _FORBIDDEN_TEXT.search(value):
+        raise Role1ContractError(f"seed value is forbidden in text at {path}")
+
+
+@dataclass(frozen=True, slots=True)
+class Role1Event:
+    """One validated decision boundary, as the model will see it.
+
+    Attributes:
+        event_id: Stable identifier for this boundary.
+        task: The RoboTwin task.
+        chunk_index: Index of the chunk boundary.
+        proposals: The Critic's proposals, most significant first.
+        features: The Critic feature plane for this boundary.
+        arm_scoped_tools: Tools the task binding declares as arm-scoped.
+    """
+
+    event_id: str
+    task: str
+    chunk_index: int
+    proposals: tuple[Mapping[str, Any], ...]
+    features: Mapping[str, Any] = field(default_factory=dict)
+    arm_scoped_tools: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Validate the event.
+
+        Raises:
+            Role1ContractError: The event has no proposal to rule on.
+        """
+        if not self.proposals:
+            raise Role1ContractError("a Role1 event must carry a Critic proposal")
+
+    @property
+    def leading_proposal(self) -> Mapping[str, Any]:
+        """The proposal Role1 is being asked to rule on.
+
+        Returns:
+            The first proposal.
+        """
+        return self.proposals[0]
+
+    @property
+    def evidence_arm(self) -> str | None:
+        """The arm the leading proposal's evidence concerns.
+
+        Returns:
+            The canonical arm name, or ``None`` when the proposal names none.
+        """
+        return arm_from_proposal(self.leading_proposal)
+
+    def model_payload(self) -> dict[str, Any]:
+        """Build the seed-blind payload handed to the model.
+
+        Returns:
+            A JSON-friendly payload.
+        """
+        payload = {
+            "event_id": self.event_id,
+            "task": self.task,
+            "chunk_index": int(self.chunk_index),
+            "robot": {
+                "kind": "bimanual",
+                "arms": list(ARMS),
+                "action_dim": 14,
+                "action_space": "absolute joint targets",
+            },
+            "evidence": {
+                "granularity": str(self.features.get(GRANULARITY_FEATURE, "chunk")),
+                "note": (
+                    "One observation per chunk. There are no intermediate "
+                    "frames; do not reason about per-step motion."
+                ),
+                "features": {
+                    key: value
+                    for key, value in sorted(self.features.items())
+                    if isinstance(value, int | float | str | bool)
+                },
+            },
+            "critic_proposals": [
+                {
+                    "rule_id": str(row.get("rule_id", "")),
+                    "proposal": str(row.get("proposal", row.get("reason", ""))),
+                    "arm": arm_from_proposal(row),
+                    "feature": row.get("feature"),
+                    "observed": row.get("observed"),
+                }
+                for row in self.proposals
+            ],
+            "arm_scoped_tools": list(self.arm_scoped_tools),
+            "response_contract": {
+                "dispositions": list(VALID_DISPOSITIONS),
+                "required_keys": ["event_id", "proposal_disposition", "arm", "reason"],
+                "arm_rule": (
+                    "`arm` must equal the arm named by the proposal you are "
+                    "ruling on. If that proposal names no arm, the only valid "
+                    "disposition is reject."
+                ),
+            },
+        }
+        assert_seed_blind(payload, path="model_payload")
+        return payload
+
+
+class Role1DecisionStore:
+    """Append-only persistence for Role1 verdicts.
+
+    A verdict that is not durably recorded before it is acted on cannot be
+    audited afterwards, so the Actor is only ever handed decisions that this
+    store has already written.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        """Initialize the store.
+
+        Args:
+            root: Directory decisions are written into.
+        """
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._records: list[dict[str, Any]] = []
+
+    def persist(
+        self, *, event: Role1Event, decision: Role1Decision, raw: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Write one verdict and return its record.
+
+        Args:
+            event: The boundary that was decided.
+            decision: The parsed verdict.
+            raw: The model's raw JSON object.
+
+        Returns:
+            The persisted record, carrying its own content hash.
+        """
+        record = {
+            "schema_version": 1,
+            "event_id": event.event_id,
+            "task": event.task,
+            "chunk_index": int(event.chunk_index),
+            "evidence_arm": event.evidence_arm,
+            "decision": decision.public_dict(),
+            "raw_model_object": dict(raw),
+        }
+        record["record_sha256"] = canonical_sha256(record)
+        atomic_write_json(self.root / f"{event.event_id}.json", record, overwrite=False)
+        self._records.append(record)
+        return record
+
+    @property
+    def records(self) -> tuple[dict[str, Any], ...]:
+        """Every verdict persisted by this store.
+
+        Returns:
+            The records in write order.
+        """
+        return tuple(self._records)
+
+
+def strict_model_json(text: str) -> dict[str, Any]:
+    """Parse exactly one bare JSON object, rejecting repairs and extra text.
+
+    Args:
+        text: The model's textual response.
+
+    Returns:
+        The parsed object.
+
+    Raises:
+        Role1ContractError: The response is empty, is not a single bare object,
+            or repeats a key.
+    """
+    source = text.strip()
+    if not source:
+        raise Role1ContractError("Role1 model returned no textual decision")
+
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise Role1ContractError(f"Role1 model repeated JSON key: {key}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(source, object_pairs_hook=unique_object)
+    except Role1ContractError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise Role1ContractError(
+            "Role1 model must return exactly one bare JSON object"
+        ) from exc
+    if not isinstance(value, dict):
+        raise Role1ContractError("Role1 model must return a JSON object")
+    return value
+
+
+def model_text(messages: Any) -> str:
+    """Extract the assistant text from a planner result.
+
+    Args:
+        messages: The planner's message list.
+
+    Returns:
+        The concatenated distinct text parts.
+
+    Raises:
+        Role1ContractError: The messages are not a list of objects.
+    """
+    if not isinstance(messages, list):
+        raise Role1ContractError("planner messages must be an array")
+    parts: list[str] = []
+    seen: set[str] = set()
+    for message in messages:
+        if not isinstance(message, Mapping):
+            raise Role1ContractError("planner message must be an object")
+        content = message.get("content")
+        chunks = content if isinstance(content, list) else [content]
+        for chunk in chunks:
+            text = (
+                chunk.get("text")
+                if isinstance(chunk, Mapping)
+                else chunk
+                if isinstance(chunk, str)
+                else None
+            )
+            if isinstance(text, str) and text.strip() and text.strip() not in seen:
+                parts.append(text.strip())
+                seen.add(text.strip())
+    return "\n".join(parts)
+
+
+def parse_decision(raw: Mapping[str, Any], *, event: Role1Event) -> Role1Decision:
+    """Validate one raw model object against the RoboTwin Role1 contract.
+
+    Args:
+        raw: The model's JSON object.
+        event: The boundary being decided.
+
+    Returns:
+        The validated verdict.
+
+    Raises:
+        Role1ContractError: A required key is missing, the disposition is
+            unknown, the event id does not match, the arm is absent or does not
+            match the evidence, or an arm-less proposal was accepted.
+    """
+    missing = [
+        key
+        for key in ("event_id", "proposal_disposition", "reason")
+        if not str(raw.get(key, "")).strip()
+    ]
+    if missing:
+        raise Role1ContractError(f"Role1 decision is missing keys: {missing}")
+    if str(raw["event_id"]) != event.event_id:
+        raise Role1ContractError("Role1 decision answers a different event")
+    disposition = str(raw["proposal_disposition"]).strip().lower()
+    if disposition not in VALID_DISPOSITIONS:
+        raise Role1ContractError(
+            f"unknown proposal_disposition {disposition!r}; "
+            f"expected one of {list(VALID_DISPOSITIONS)}"
+        )
+    accepted = disposition == "accept"
+    evidence_arm = event.evidence_arm
+    supplied = raw.get("arm")
+    arm: str | None = None
+    if supplied is not None and str(supplied).strip():
+        try:
+            arm = normalize_arm(str(supplied))
+        except ArmSelectionError as exc:
+            raise Role1ContractError(f"Role1 decision names an unusable arm: {exc}")
+
+    if accepted:
+        if evidence_arm is None:
+            raise Role1ContractError(
+                "Role1 accepted a proposal that names no arm; a RoboTwin "
+                "recovery cannot be executed without one"
+            )
+        if arm is None:
+            raise Role1ContractError(
+                "Role1 accepted an arm-scoped proposal without naming the arm"
+            )
+        if arm != evidence_arm:
+            # The model may not redirect the evidence to the other hand: the
+            # audit would read as compliant while authorising something the
+            # Critic never observed.
+            raise Role1ContractError(
+                f"Role1 ruled on the {arm} arm but the evidence concerns the "
+                f"{evidence_arm} arm"
+            )
+    return Role1Decision(
+        accepted=accepted,
+        reason=str(raw["reason"]).strip(),
+        proposal_id=str(event.leading_proposal.get("rule_id") or "") or None,
+        arm=arm if accepted else (arm or evidence_arm),
+    )
+
+
+class ModelBackedRole1:
+    """A ``Role1Decider`` backed by the shared planner stack.
+
+    The adapter never repairs invalid model output: a verdict that does not meet
+    the contract is a contract failure, and silently fixing it would hide the
+    fact that the model was not following the rules the campaign froze.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: Role1DecisionStore,
+        binding: Any,
+        output_root: str | Path,
+        planner_type: Literal["api", "codex"] = "codex",
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+        base_url: str | None = None,
+        max_tokens: int = 4096,
+        timeout_s: int = 600,
+        max_turns: int = 2,
+        planner: Any | None = None,
+        planner_factory: Any = None,
+        fail_closed: bool = True,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            store: Where verdicts are persisted.
+            binding: The task's frozen tool binding.
+            output_root: Directory for per-invocation artifacts.
+            planner_type: ``"api"`` or ``"codex"``.
+            model: Model identifier.
+            reasoning_effort: Reasoning effort, when the backend supports it.
+            base_url: Override base URL.
+            max_tokens: Response budget.
+            timeout_s: Planner timeout.
+            max_turns: Maximum planner turns.
+            planner: Injected planner, for tests.
+            planner_factory: Factory used when no planner is injected.
+            fail_closed: Whether a model or contract failure becomes a rejection
+                rather than an exception. Rejecting continues the episode on the
+                policy's own chunk, which is the safe direction: a Role1 that
+                cannot be reached must not be able to authorise a recovery.
+
+        Raises:
+            ValueError: A limit is not positive, or the planner type is unknown.
+        """
+        if planner_type not in {"api", "codex"}:
+            raise ValueError("ModelBackedRole1 supports only api or codex planners")
+        if max_tokens <= 0 or timeout_s <= 0 or max_turns <= 0:
+            raise ValueError("model limits must be positive")
+        self.store = store
+        self.binding = binding
+        self.output_root = Path(output_root)
+        self.planner_type = planner_type
+        self.model = model
+        self.reasoning_effort = reasoning_effort
+        self.base_url = base_url
+        self.max_tokens = max_tokens
+        self.timeout_s = timeout_s
+        self.max_turns = max_turns
+        self._planner = planner
+        self._planner_factory = planner_factory
+        self.fail_closed = fail_closed
+
+    def _build_planner(self, invocation: Path) -> Any:
+        """Return the planner for one invocation.
+
+        Args:
+            invocation: Directory for this invocation's artifacts.
+
+        Returns:
+            The planner instance.
+        """
+        if self._planner is not None:
+            return self._planner
+        factory = self._planner_factory
+        if factory is None:
+            from zetta.planner.base import build_planner
+
+            factory = build_planner
+        return factory(
+            self.planner_type,
+            output_dir=invocation,
+            recipe_tag="role1-decision",
+            env_name="robotwin",
+            base_url=self.base_url,
+            model=self.model,
+            reasoning_effort=self.reasoning_effort,
+            max_tokens=self.max_tokens,
+            planner_timeout_s=self.timeout_s,
+            no_images=True,
+        )
+
+    def decide(
+        self,
+        *,
+        task: str,
+        chunk_index: int,
+        features: Mapping[str, Any],
+        proposals: Sequence[Mapping[str, Any]],
+    ) -> Role1Decision:
+        """Obtain, validate and persist one verdict.
+
+        Args:
+            task: The task under evaluation.
+            chunk_index: The chunk boundary index.
+            features: The Critic feature plane.
+            proposals: The Critic's proposals.
+
+        Returns:
+            The verdict. On a model or contract failure with ``fail_closed``,
+            a rejection carrying the failure reason; with ``fail_closed`` off,
+            :meth:`_failed` re-raises the original ``Role1ModelError`` or
+            ``Role1ContractError`` instead.
+        """
+        if not proposals:
+            return Role1Decision(accepted=False, reason="no critic proposal")
+        event = Role1Event(
+            event_id=f"role1-{chunk_index:06d}-{uuid.uuid4().hex[:8]}",
+            task=task,
+            chunk_index=int(chunk_index),
+            proposals=tuple(dict(row) for row in proposals),
+            features=dict(features),
+            arm_scoped_tools=tuple(
+                getattr(self.binding, "arm_scoped_tool_names", ()) or ()
+            ),
+        )
+        invocation = self.output_root / event.event_id
+        invocation.mkdir(parents=True, exist_ok=True)
+        payload = event.model_payload()
+        atomic_write_json(
+            invocation / "input.json",
+            {
+                "system_contract": ROLE1_SYSTEM_CONTRACT,
+                "user_payload": payload,
+                "planner_type": self.planner_type,
+                "model": self.model,
+            },
+            overwrite=False,
+        )
+        started = time.monotonic()
+        try:
+            planner = self._build_planner(invocation)
+            result = planner.solve(
+                system_prompt=ROLE1_SYSTEM_CONTRACT,
+                user_message=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                toolkit=None,
+                max_turns=self.max_turns,
+            )
+            raw = strict_model_json(model_text(getattr(result, "messages", None)))
+            decision = parse_decision(raw, event=event)
+        except (Role1ContractError, Role1ModelError) as exc:
+            return self._failed(event, invocation, exc, started)
+        except Exception as exc:  # noqa: BLE001 - any planner failure is a Role1 failure
+            return self._failed(event, invocation, Role1ModelError(str(exc)), started)
+        atomic_write_json(
+            invocation / "timing.json",
+            {"elapsed_s": round(time.monotonic() - started, 3)},
+            overwrite=False,
+        )
+        self.store.persist(event=event, decision=decision, raw=raw)
+        return decision
+
+    def _failed(
+        self,
+        event: Role1Event,
+        invocation: Path,
+        exc: BaseException,
+        started: float,
+    ) -> Role1Decision:
+        """Record a failure and either reject or re-raise.
+
+        Args:
+            event: The boundary being decided.
+            invocation: The invocation directory.
+            exc: The failure.
+            started: Monotonic start time.
+
+        Returns:
+            A rejection, when failing closed. With ``fail_closed`` off the
+            original failure is re-raised unchanged, so a campaign that wants
+            Role1 outages to be loud gets them.
+        """
+        atomic_write_json(
+            invocation / "failure.json",
+            {
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "elapsed_s": round(time.monotonic() - started, 3),
+            },
+            overwrite=False,
+        )
+        if not self.fail_closed:
+            raise exc
+        # Rejecting continues on the policy's own chunk. The opposite default --
+        # accepting when Role1 is unreachable -- would let an outage authorise
+        # recoveries nobody ruled on.
+        decision = Role1Decision(
+            accepted=False,
+            reason=f"role1 unavailable: {type(exc).__name__}: {exc}",
+            proposal_id=str(event.leading_proposal.get("rule_id") or "") or None,
+            arm=event.evidence_arm,
+        )
+        self.store.persist(event=event, decision=decision, raw={"error": str(exc)})
+        return decision
+
+
+__all__ = [
+    "ModelBackedRole1",
+    "Role1ContractError",
+    "Role1DecisionStore",
+    "Role1Event",
+    "Role1ModelError",
+    "assert_seed_blind",
+    "model_text",
+    "parse_decision",
+    "strict_model_json",
+]

--- a/robots/robotwin/run_rollout.py
+++ b/robots/robotwin/run_rollout.py
@@ -1,0 +1,1372 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Pure-VLA RoboTwin rollout entrypoint.
+
+This is the **sole** file on the ``robots``/``zetta`` side allowed to import
+``rollout_runtime`` (``tests/runtime/test_layering.py``): everything else under
+``robots/robotwin/`` is contract-level and simulator-free.
+
+Scope, stated plainly: this drives one frozen episode through the shared
+Rollout Runtime and writes an ``EpisodeRecord``. It is the **pure-VLA** path --
+observe, infer, execute, repeat -- with no Role1 review, no runtime Critic and
+no recovery controller. Those are the next increment; wiring them in before the
+bimanual action and tool contracts had been exercised against real hardware
+would have meant freezing a tool catalog nobody had run.
+
+Two RoboTwin-specific facts shape the loop:
+
+- The family is ``final_only``. One ``policy_step`` submits a whole chunk and
+  returns exactly one observation, so ``StepResult.per_step`` is always
+  ``None``; per-step evidence does not exist and the loop must not pretend
+  otherwise. The executed horizon comes back in ``info["executed_horizon"]``.
+- The seed **is** the scene. RoboTwin's ``env_seeds`` selects the initial
+  configuration outright, so the episode seed rides in
+  ``ResetSpec.reset_state_id`` rather than in ``seed``, and a paired same-seed
+  gate reproduces the scene exactly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import hashlib
+import io
+import json
+import time
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from robots.robotwin.action_contract import ACTION_DIM
+from robots.robotwin.critic_runtime import (
+    critic_rules_from_payload,
+    describe_dwell_semantics,
+    extract_robotwin_critic_features,
+    next_stall_counts,
+    robotwin_state_features,
+)
+from robots.robotwin.recovery_controller import RecoveryController
+from robots.robotwin.role1_actor import ArmAwareRole1, Role1EpisodeActor
+from robots.robotwin.role1_agent import ModelBackedRole1, Role1DecisionStore
+from robots.robotwin.tool_bindings import binding_for_task
+from robots.robotwin.tool_catalog import DEFAULT_ROBOTWIN_TOOL_CATALOG
+from rollout_runtime.api.ids import SessionId
+from rollout_runtime.api.messages import (
+    CreateSessionRequest,
+    EnvSpecMsg,
+    PolicyRequest,
+    ResetSpec,
+    StepResult,
+)
+from rollout_runtime.api.result import Err, Result
+from rollout_runtime.core.payload import decode_array, encode_array
+from rollout_runtime.serve.client import RemoteRuntimeClient
+from zetta.evolution.critic import TemporalCritic
+from zetta.evolution.jsonio import atomic_write_json, canonical_sha256, read_json
+from zetta.evolution.models import CandidateBundle, EpisodeRecord
+from zetta.evolution.trajectory import TrajectoryArtifacts, index_episode_trajectory
+from zetta.evolution.visual_artifacts import build_episode_visual_artifacts
+
+RUNTIME_APPLICATION_ID = "zetta-robotwin"
+"""Tenant identity reported to the Gateway; the bearer token is authoritative."""
+
+
+def _now() -> str:
+    """Return an ISO-8601 UTC timestamp.
+
+    Returns:
+        The current time in UTC.
+    """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _append_jsonl(path: Path, value: dict[str, Any]) -> None:
+    """Append one JSON object to a JSONL file.
+
+    Args:
+        path: Target file; parent directories are created.
+        value: The record to append.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(value, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+class RuntimeOperationError(RuntimeError):
+    """A Runtime operation returned an error result."""
+
+
+def _single(results: Sequence[Result[Any]], *, operation: str) -> Any:
+    """Unwrap a batch-of-one Runtime result.
+
+    Args:
+        results: The returned results.
+        operation: Operation name, for the error message.
+
+    Returns:
+        The single successful value.
+
+    Raises:
+        RuntimeOperationError: The batch was not of size one, or carried an
+            error.
+    """
+    if len(results) != 1:
+        raise RuntimeOperationError(
+            f"{operation} returned {len(results)} results, expected 1"
+        )
+    result = results[0]
+    if isinstance(result, Err):
+        raise RuntimeOperationError(f"{operation} failed: {result.error}")
+    return getattr(result, "value", result)
+
+
+class RolloutSession:
+    """One rollout's view of the shared Runtime: a single session, unbatched.
+
+    Attributes:
+        client: The shared runtime's HTTP client.
+        session_id: This rollout's session.
+        lease_seconds: Requested lease length; the server may clamp it.
+        lease_expiration: Current lease deadline as a unix timestamp.
+        episode_started: Whether ``reset`` has completed at least once.
+        closed: Whether the session has been closed.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        session_id: SessionId,
+        *,
+        lease_seconds: float,
+        lease_expiration: float,
+    ) -> None:
+        """Initialize the adapter.
+
+        Args:
+            client: A ``RemoteRuntimeClient``-shaped object.
+            session_id: The created session.
+            lease_seconds: Requested lease length.
+            lease_expiration: Lease deadline from ``create_sessions``.
+        """
+        self.client = client
+        self.session_id = session_id
+        self.lease_seconds = float(lease_seconds)
+        self.lease_expiration = float(lease_expiration)
+        self.episode_started = False
+        self.closed = False
+
+    @property
+    def _ids(self) -> list[SessionId]:
+        """The session id as a batch of one.
+
+        Returns:
+            A single-element list.
+        """
+        return [self.session_id]
+
+    async def reset(self, reset_spec: ResetSpec) -> StepResult:
+        """Reset the episode.
+
+        Args:
+            reset_spec: Episode parameters. For RoboTwin the scene is selected
+                by ``reset_state_id``.
+
+        Returns:
+            The reset step result.
+        """
+        step = _single(
+            await self.client.reset(self._ids, reset_spec), operation="reset"
+        )
+        self.episode_started = True
+        return step
+
+    async def policy_step(self, policy_request: PolicyRequest) -> StepResult:
+        """Atomic observe -> infer -> chunk_step.
+
+        Args:
+            policy_request: Inference parameters.
+
+        Returns:
+            The step result.
+        """
+        return _single(
+            await self.client.policy_step(self._ids, policy_request),
+            operation="policy_step",
+        )
+
+    async def policy_infer(
+        self, policy_request: PolicyRequest
+    ) -> tuple[list[list[float]], dict[str, Any]]:
+        """Infer without writing to the environment (the Role1 review path).
+
+        Args:
+            policy_request: Inference parameters.
+
+        Returns:
+            ``(actions, metadata)``; ``actions`` is the nested float list that
+            Role1 and ``action_step`` both expect.
+
+        Raises:
+            RuntimeOperationError: The policy returned no usable action chunk.
+        """
+        result = _single(
+            await self.client.policy_infer(self._ids, policy_request),
+            operation="policy_infer",
+        )
+        if result.actions is None:
+            raise RuntimeOperationError("policy_infer returned no action chunk")
+        block = np.asarray(decode_array(result.actions), dtype=np.float32)
+        if block.ndim != 2 or block.shape[1] != ACTION_DIM:
+            raise RuntimeOperationError(
+                f"policy_infer returned shape {tuple(int(v) for v in block.shape)}, "
+                f"expected [chunk, {ACTION_DIM}]"
+            )
+        metadata = {
+            "source": "policy_infer",
+            "horizon": int(block.shape[0]),
+            "model_version": result.model_version,
+        }
+        return [[float(value) for value in row] for row in block], metadata
+
+    async def action_step(self, actions: Sequence[Sequence[float]]) -> StepResult:
+        """Execute an action chunk Role1 has already reviewed.
+
+        Args:
+            actions: ``[chunk, 14]`` actions.
+
+        Returns:
+            The step result.
+        """
+        block = np.asarray(actions, dtype=np.float32)
+        return _single(
+            await self.client.action_step(self._ids, [encode_array(block)]),
+            operation="action_step",
+        )
+
+    async def renew_if_needed(self, *, now: float | None = None) -> None:
+        """Renew the lease before it can expire mid-episode.
+
+        Args:
+            now: Injectable clock reading; defaults to ``time.time()``.
+        """
+        moment = time.time() if now is None else now
+        margin = max(30.0, self.lease_seconds / 4.0)
+        if moment < self.lease_expiration - margin:
+            return
+        status = _single(
+            await self.client.renew_sessions(self._ids, self.lease_seconds),
+            operation="renew_sessions",
+        )
+        self.lease_expiration = float(status.lease_expiration)
+
+    async def close(self) -> dict[str, Any]:
+        """Close the session, returning its slot to the pool.
+
+        Returns:
+            ``{"session_closed": bool, ...}``; a failure is reported rather
+            than raised so cleanup cannot mask the episode's own outcome.
+        """
+        try:
+            _single(
+                await self.client.close_sessions(self._ids),
+                operation="close_sessions",
+            )
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask the outcome
+            return {
+                "session_closed": False,
+                "session_id": str(self.session_id),
+                "failure_class": type(exc).__name__,
+            }
+        self.closed = True
+        return {"session_closed": True, "session_id": str(self.session_id)}
+
+
+def _chunk_record(step: StepResult, *, index: int) -> dict[str, Any]:
+    """Summarise one chunk into an audit row.
+
+    ``per_step`` is always ``None`` for this family, so the row is chunk-
+    granular by construction. It records that explicitly rather than leaving a
+    reader to infer it from an absent field.
+
+    Args:
+        step: The step result.
+        index: The chunk's index within the episode.
+
+    Returns:
+        A JSON-friendly row.
+    """
+    info = dict(step.info or {})
+    return {
+        "at": _now(),
+        "chunk_index": index,
+        # `StepResult.executed_horizon` is the canonical count; the adapter also
+        # echoes it into `info` alongside the discard bookkeeping.
+        "executed_horizon": int(step.executed_horizon) or info.get("executed_horizon"),
+        "requested_horizon": info.get("requested_horizon"),
+        "discarded_actions": info.get("discarded_actions"),
+        "reward": float(step.reward),
+        "terminated": bool(step.terminated),
+        "truncated": bool(step.truncated),
+        "success": info.get("success"),
+        "per_step_available": step.per_step is not None,
+        "evidence_granularity": "chunk",
+    }
+
+
+def _camera_refs(observation: Any) -> list[tuple[str, Any]]:
+    """Return this observation's populated camera payloads, named.
+
+    The family delivers the right wrist as the first extra view rather than as
+    a second ``wrist_image``; naming the cameras in one place keeps the video
+    recorder and the reset identity from drifting apart.
+
+    Args:
+        observation: The observation to read; ``None`` yields no cameras.
+
+    Returns:
+        ``(camera name, payload ref)`` for each camera that is present.
+    """
+
+    if observation is None:
+        return []
+    candidates = (
+        ("head", observation.main_image),
+        ("left_wrist", observation.wrist_image),
+        (
+            "right_wrist",
+            observation.extra_view_images[0]
+            if observation.extra_view_images
+            else None,
+        ),
+    )
+    return [(name, ref) for name, ref in candidates if ref is not None]
+
+
+def _reset_observation_identity(observation: Any) -> dict[str, Any]:
+    """Bind a paired gate to the physical reset this episode actually got.
+
+    ``gate_runner._source_parent_for_pair`` rejects a same-seed parent whose
+    ``artifact_index`` carries no ``initial_observation_identity``, and
+    ``gating._same_physical_reset`` treats ``state_sha256`` as the stable
+    binding while camera digests are audited for renderer drift without
+    deciding the comparison.
+
+    LIBERO and RoboCasa build this from a privileged snapshot; RoboTwin
+    declares no extensions, so the identity is the reset state vector the
+    policy itself saw.  That is exact rather than approximate here: the seed is
+    the scene, and pinning ``reset_state_id`` to it reproduces the
+    configuration bit for bit.
+
+    Args:
+        observation: The reset observation.
+
+    Returns:
+        The identity mapping, or an empty mapping when there is no observation.
+    """
+
+    if observation is None:
+        return {}
+    state = list(observation.state) if observation.state is not None else []
+    return {
+        "state_sha256": canonical_sha256(state),
+        "camera_sha256": {
+            name: hashlib.sha256(ref.data).hexdigest()
+            for name, ref in _camera_refs(observation)
+        },
+    }
+
+
+class FrameRecorder:
+    """Accumulate per-camera frames and encode one video per camera.
+
+    RoboTwin records nothing itself -- ``robotwin/envs/vector_env.py`` sets
+    ``eval_video_log = False`` unconditionally -- so the only frames that exist
+    are the ones already inside each ``Observation``, PNG-encoded by the payload
+    layer. This collects those bytes and encodes them at the end; nothing is
+    re-rendered, so the video is exactly what the policy saw.
+
+    Videos matter beyond being nice to look at: Stage 1 refuses a diagnosis with
+    fewer than three visual evidence items
+    (``lifecycle.py`` ``len(diagnosis.visual_evidence) < 3``), and
+    ``build_episode_visual_artifacts`` needs at least two synchronized cameras.
+
+    Attributes:
+        root: Directory the videos are written into.
+        fps: Frame rate of the written videos.
+    """
+
+    def __init__(self, root: Path, *, fps: int = 20) -> None:
+        """Initialize an empty recorder.
+
+        Args:
+            root: Output directory.
+            fps: Frame rate for the encoded videos.
+        """
+        self.root = Path(root)
+        self.fps = int(fps)
+        self._frames: dict[str, list[bytes]] = {}
+
+    def capture(self, observation: Any) -> None:
+        """Record one step's frames from an observation.
+
+        Args:
+            observation: The observation to read; ``None`` is ignored.
+        """
+        if observation is None:
+            return
+        for name, ref in _camera_refs(observation):
+            self._frames.setdefault(name, []).append(ref.data)
+
+    @property
+    def frame_count(self) -> int:
+        """Number of frames captured for the densest camera.
+
+        Returns:
+            The maximum per-camera frame count.
+        """
+        return max((len(rows) for rows in self._frames.values()), default=0)
+
+    def encode(self) -> dict[str, str]:
+        """Write one video per camera.
+
+        Returns:
+            Camera name -> written path. Empty when nothing was captured or no
+            encoder is available; the caller degrades rather than failing, so a
+            missing ffmpeg costs visual evidence but not the episode.
+        """
+        if not self._frames:
+            return {}
+        try:
+            import imageio.v2 as iio
+        except ImportError:
+            return {}
+        self.root.mkdir(parents=True, exist_ok=True)
+        written: dict[str, str] = {}
+        for name, payloads in sorted(self._frames.items()):
+            target = self.root / f"{name}.mp4"
+            try:
+                images = [iio.imread(io.BytesIO(data)) for data in payloads]
+                iio.mimsave(target, images, fps=self.fps, codec="libx264")
+            except Exception:  # noqa: BLE001 - encoder availability varies by host
+                continue
+            written[name] = str(target)
+        return written
+
+
+def _append_action_rows(
+    path: Path,
+    actions: Sequence[Sequence[float]] | None,
+    *,
+    first_step_index: int,
+    source: str,
+) -> None:
+    """Record one row per executed action.
+
+    ``actions`` is ``None`` on the pure-VLA fast path: ``policy_step`` performs
+    inference and execution inside the Runtime in one operation, so the client
+    genuinely never sees the individual actions. That is not a gap to paper
+    over -- ``_make_events`` derives ``action_count`` from the chunk rows'
+    ``executed_horizon`` instead, so the trajectory index stays correct with an
+    empty actions artifact.
+
+    Args:
+        path: The actions JSONL.
+        actions: The executed ``[chunk, 14]`` block, or ``None``.
+        first_step_index: Env step index of the block's first action.
+        source: ``"vla"``, ``"recovery"`` or ``"hold"``.
+    """
+    if actions is None:
+        return
+    for offset, action in enumerate(actions):
+        values = [float(value) for value in action]
+        _append_jsonl(
+            path,
+            {
+                "at": _now(),
+                "step_index": first_step_index + offset,
+                "source": source,
+                "action_dim": len(values),
+                "action": values,
+            },
+        )
+
+
+def _state_row(
+    state: Sequence[float],
+    *,
+    step_index: int,
+    chunk_index: int,
+    step: StepResult,
+) -> dict[str, Any]:
+    """Build one state-timeline row from a chunk-final observation.
+
+    RoboTwin is ``final_only``, so this timeline is **chunk-final**, not
+    per-step: there are ``ceil(max_steps / execute_horizon)`` rows for an
+    episode, not one per simulator step. ``evidence_granularity`` records that
+    in the row itself rather than leaving a reader to infer it from the row
+    count.
+
+    The row deliberately carries **no** ``task_progress`` / ``residual_to_success``
+    field. ``trajectory._window_no_progress`` keys off exactly those names, and
+    RoboTwin exposes no task-grounded progress scalar without a privileged
+    simulator feature, which this family does not declare
+    (``extensions=frozenset()`` in ``env_registry.py``). Publishing joint travel
+    under a name the detector reads would make "the robot stopped moving" look
+    like "the task stopped progressing"; those are different claims and the
+    second one would be fabricated.
+
+    Args:
+        state: The 14-dim joint state.
+        step_index: Env step index this observation belongs to.
+        chunk_index: The chunk that produced it.
+        step: The step result, for reward and flags.
+
+    Returns:
+        A JSON-friendly row.
+    """
+    values = [float(value) for value in state]
+    return {
+        "at": _now(),
+        "step_index": int(step_index),
+        "chunk_index": int(chunk_index),
+        "evidence_granularity": "chunk",
+        "reward": float(step.reward),
+        "terminated": bool(step.terminated),
+        "truncated": bool(step.truncated),
+        "state": {
+            # Runtime feature names, from the same function the Critic plane is
+            # built with.  An earlier revision published a nested
+            # ``{"left": {"gripper": ...}}`` here, which
+            # lifecycle._observed_critic_features flattened to "left.gripper";
+            # Stage2 bound that name and every gate rollout then died on
+            # "critic feature is unavailable: left.gripper", because the Critic
+            # evaluates "robotwin.arm.left.gripper".
+            **robotwin_state_features(values),
+            # Raw evidence.  A list is not a scalar, so this adds no name to the
+            # vocabulary Stage2 may bind.
+            "joint_positions": values,
+        },
+    }
+
+
+def _optional_sha(value: str | None) -> str | None:
+    """Normalise the campaign's ``"none"`` sentinel into ``None``.
+
+    ``campaign.py`` substitutes ``{bundle_sha256}`` with ``current_bundle or
+    "none"``, so a Gen0 rollout receives the literal string ``"none"``.
+    ``EpisodeRecord`` validates the field as a 64-character sha256 and rejects
+    it, which surfaces as every Gen0 episode failing as ``infra_invalid``.
+
+    Args:
+        value: The supplied digest, the ``"none"`` sentinel, or ``None``.
+
+    Returns:
+        The digest, or ``None``.
+    """
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return None if not cleaned or cleaned == "none" else cleaned
+
+
+def _visual_evidence(
+    *,
+    video_paths: dict[str, str],
+    states_path: Path,
+    output_root: Path,
+    segments: Sequence[Any],
+) -> dict[str, Any] | None:
+    """Build the multimodal evidence Stage 1 requires, when it is possible.
+
+    ``lifecycle`` refuses a provisional diagnosis carrying fewer than three
+    visual evidence items, and ``build_episode_visual_artifacts`` needs at least
+    two synchronized cameras. Both conditions are met only when the episode ran
+    with ``--capture-frames``; a run without it still produces a valid episode,
+    it just cannot be diagnosed.
+
+    A failure to build is reported rather than raised: visual evidence is
+    downstream of the episode's own outcome, and losing it must not turn a valid
+    episode into an infrastructure failure.
+
+    Args:
+        video_paths: Camera name -> encoded video path.
+        states_path: The state-timeline JSONL.
+        output_root: Directory to create the evidence in.
+        segments: The episode's failure segments, for divergence windows.
+
+    Returns:
+        The evidence manifest, or a dict explaining why there is none.
+    """
+    if len(video_paths) < 2:
+        return {
+            "available": False,
+            "reason": (
+                "fewer than two synchronized cameras were recorded; rerun with "
+                "--capture-frames to make this episode diagnosable"
+            ),
+            "camera_count": len(video_paths),
+        }
+    try:
+        return build_episode_visual_artifacts(
+            video_paths=dict(video_paths),
+            states_path=states_path,
+            output_root=output_root,
+            divergence_steps=tuple(
+                segment.earliest_divergence_step
+                for segment in segments
+                if segment.earliest_divergence_step is not None
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 - evidence must not fail the episode
+        return {
+            "available": False,
+            "reason": f"{type(exc).__name__}: {exc}",
+            "camera_count": len(video_paths),
+        }
+
+
+async def _execute_block(
+    session: RolloutSession,
+    block: Sequence[Sequence[float]],
+    *,
+    recorder: FrameRecorder | None,
+    states_path: Path,
+    first_step_index: int,
+    chunk_index: int,
+) -> tuple[StepResult, int]:
+    """Execute one decided action block and record the state timeline.
+
+    Two submission shapes, and the choice is purely about **observation
+    density**, not physics: submitting a block of N and submitting its N actions
+    one at a time produce bit-identical joint states at every matched step
+    (measured on ``adjust_bottle``/aloha-agilex/mplib, max delta 0.0). What
+    changes is that stepwise submission yields an observation -- and therefore a
+    state row and a frame -- after every simulator step, instead of one per
+    chunk.
+
+    That resolution is what the evidence machinery is built for:
+    ``index_episode_trajectory``'s ``context_before``/``context_after``/
+    ``no_progress_window`` all default to 8 **rows**, which at chunk granularity
+    would span an entire episode.
+
+    Args:
+        session: The bound rollout session.
+        block: The ``[chunk, 14]`` actions to execute.
+        recorder: Frame recorder, or ``None`` to submit the block whole.
+        states_path: The state-timeline JSONL.
+        first_step_index: Env step index before this block.
+        chunk_index: The chunk this block belongs to.
+
+    Returns:
+        ``(final_step_result, executed_action_count)``.
+    """
+    if recorder is None:
+        step = await session.action_step(block)
+        executed = int(step.executed_horizon) or len(block)
+        if step.observation is not None:
+            _append_jsonl(
+                states_path,
+                _state_row(
+                    list(step.observation.state),
+                    step_index=first_step_index + executed,
+                    chunk_index=chunk_index,
+                    step=step,
+                ),
+            )
+        return step, executed
+
+    step: StepResult | None = None
+    executed = 0
+    for action in block:
+        step = await session.action_step([action])
+        executed += int(step.executed_horizon) or 1
+        if step.observation is not None:
+            recorder.capture(step.observation)
+            _append_jsonl(
+                states_path,
+                _state_row(
+                    list(step.observation.state),
+                    step_index=first_step_index + executed,
+                    chunk_index=chunk_index,
+                    step=step,
+                ),
+            )
+        if step.terminated or step.truncated:
+            # Stepwise submission sees termination the moment it happens.
+            # A chunked submission would keep executing to the end of the block
+            # -- up to horizon-1 steps past the terminal state.
+            break
+    if step is None:
+        raise RuntimeOperationError("action block was empty")
+    return step, executed
+
+
+def _env_spec(args: argparse.Namespace) -> EnvSpecMsg:
+    """Build the env spec that selects (or creates) this episode's env pool.
+
+    Every field here enters ``EnvSpecMsg.digest()``, which is the pool key, so
+    all rollout processes of one campaign must pass identical values or each
+    will cold-start its own SAPIEN pool. Per-episode values (the seed) ride in
+    ``ResetSpec`` instead.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The env spec for ``create_sessions``.
+    """
+    return EnvSpecMsg(
+        env_family="robotwin",
+        env_config={
+            "task_name": args.task,
+            "assets_path": args.assets_path,
+            "embodiment": list(args.embodiment),
+            "planner_backend": args.planner_backend,
+            "max_episode_steps": int(args.env_max_steps),
+            "step_lim": int(args.env_max_steps),
+            "execute_horizon": int(args.execute_horizon),
+            "collect_wrist_camera": True,
+            "collect_head_camera": True,
+            "center_crop": bool(args.center_crop),
+        },
+        pool_size=int(args.env_pool_size),
+        resource_hints={"accelerator": True},
+    )
+
+
+def _observation_features(
+    step: StepResult,
+    *,
+    chunk_index: int,
+    executed_horizon: int,
+    previous_state: list[float] | None,
+    stall_counts: dict[str, int],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the Critic feature plane from a chunk-final step result.
+
+    Args:
+        step: The step just executed.
+        chunk_index: Index of the chunk.
+        executed_horizon: Simulator steps the chunk advanced.
+        previous_state: The previous chunk-final joint state.
+        stall_counts: Running per-arm stall counters.
+
+    Returns:
+        ``(observation, features)``; the observation is the small dict the
+        Critic and the Actor both read.
+    """
+    state = list(step.observation.state) if step.observation is not None else None
+    observation: dict[str, Any] = {"state": state}
+    info = dict(step.info or {})
+    features = extract_robotwin_critic_features(
+        observation,
+        chunk_index=chunk_index,
+        executed_horizon=executed_horizon,
+        reward=float(step.reward),
+        terminated=bool(step.terminated),
+        truncated=bool(step.truncated),
+        previous_state=previous_state,
+        stall_counts=stall_counts,
+    )
+    features["robotwin.chunk.success"] = bool(info.get("success", False))
+    return observation, features
+
+
+def _load_rules(path: str | None) -> list[dict[str, Any]]:
+    """Read a frozen rule list from JSON, tolerating an absent path.
+
+    Args:
+        path: Path to a JSON list, or ``None``.
+
+    Returns:
+        The rule list; empty when no path was given.
+    """
+    if not path:
+        return []
+    value = read_json(Path(path))
+    return list(value) if isinstance(value, list) else list(value.get("rules", []))
+
+
+def _load_bundle(args: argparse.Namespace) -> CandidateBundle | None:
+    """Load the frozen candidate bundle a gate arm runs under.
+
+    A paired gate refuses a rollout command that cannot consume the bundle
+    artifact (``gate_runner._command_template`` requires ``{bundle_file}``),
+    because both arms must be pinned to one immutable behaviour change rather
+    than to whatever rule files happen to sit on disk.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The bundle, or ``None`` for a Gen0 rollout that has none.
+
+    Raises:
+        ValueError: If loose rule files are combined with a bundle, or the
+            bundle does not match the digest the campaign froze.
+    """
+
+    path = getattr(args, "bundle", None)
+    if not path or path == "none":
+        return None
+    if args.critic_rules or args.recovery_rules:
+        raise ValueError(
+            "--bundle is exclusive with --critic-rules/--recovery-rules: a gate "
+            "arm takes its rules from the frozen bundle alone"
+        )
+    bundle = CandidateBundle.from_dict(read_json(Path(path)))
+    expected = _optional_sha(args.bundle_sha256)
+    if expected is not None and bundle.sha256 != expected:
+        raise ValueError("candidate bundle SHA does not match --bundle-sha256")
+    return bundle
+
+
+async def _run_episode(
+    args: argparse.Namespace, session: RolloutSession, *, env_spec_digest: str
+) -> EpisodeRecord:
+    """Drive one episode to completion.
+
+    Two paths share this function. Without frozen critic rules it is the
+    **pure-VLA** path: one atomic ``policy_step`` per chunk. With them it is the
+    **reviewed** path: ``policy_infer`` produces a proposal, the Critic reads the
+    chunk-final evidence, Role1 rules on it, and only then does ``action_step``
+    write to the simulator. The split matters because only the second path can
+    execute a recovery, and only the first can be used as a clean baseline.
+
+    Args:
+        args: Parsed CLI arguments.
+        session: The bound rollout session.
+        env_spec_digest: The pool key reported by ``create_sessions``.
+
+    Returns:
+        The episode record.
+    """
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    chunks_path = output_dir / "chunks.jsonl"
+    actions_path = output_dir / "actions.jsonl"
+    states_path = output_dir / "states.jsonl"
+    tools_path = output_dir / "tools.jsonl"
+    decisions_path = output_dir / "role1_decisions.jsonl"
+    # `_strict_jsonl` reads all four unconditionally and raises on a missing
+    # file, so a run that records nothing of a given kind must still leave an
+    # empty artifact rather than no artifact.
+    for path in (chunks_path, actions_path, states_path, tools_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch(exist_ok=True)
+
+    binding = binding_for_task(args.task)
+    bundle = _load_bundle(args)
+    if bundle is not None:
+        critic_rules = critic_rules_from_payload(
+            [rule.as_dict() for rule in bundle.critic_rules]
+        )
+        recovery_rules = [rule.as_dict() for rule in bundle.recovery_rules]
+    else:
+        critic_rules = critic_rules_from_payload(_load_rules(args.critic_rules))
+        recovery_rules = _load_rules(args.recovery_rules)
+    reviewed = bool(critic_rules)
+
+    critic = TemporalCritic(critic_rules) if reviewed else None
+    controller = (
+        RecoveryController(
+            bundle_sha256=_optional_sha(args.bundle_sha256) or "0" * 64,
+            audit_path=output_dir / "recovery.jsonl",
+        )
+        if reviewed and recovery_rules
+        else None
+    )
+    decider: Any = ArmAwareRole1()
+    if reviewed and args.role1_model:
+        # A model-backed Role1 is only meaningful once a bundle is active: Gen0
+        # freezes an empty critic rule set, so no proposal ever reaches Role1
+        # and a provider call would buy nothing.
+        decider = ModelBackedRole1(
+            store=Role1DecisionStore(output_dir / "role1"),
+            binding=binding,
+            output_root=output_dir / "role1-invocations",
+            planner_type=args.role1_planner,
+            model=args.role1_model,
+            reasoning_effort=args.reasoning_effort,
+            max_tokens=int(args.role1_max_tokens),
+            timeout_s=int(args.role1_timeout_s),
+            max_turns=int(args.role1_max_turns),
+        )
+    actor = (
+        Role1EpisodeActor(decider=decider, binding=binding, recovery=controller)
+        if reviewed
+        else None
+    )
+
+    recorder = (
+        FrameRecorder(output_dir / "video", fps=int(args.video_fps))
+        if args.capture_frames
+        else None
+    )
+
+    started_at = _now()
+    started_monotonic = time.monotonic()
+
+    # RoboTwin's seed *is* the scene: pin it through reset_state_id so a paired
+    # same-seed gate reproduces the configuration exactly.
+    reset_step = await session.reset(
+        ResetSpec(seed=int(args.seed), reset_state_id=int(args.seed))
+    )
+    previous_state = (
+        list(reset_step.observation.state)
+        if reset_step.observation is not None
+        else None
+    )
+    initial_observation_identity = _reset_observation_identity(reset_step.observation)
+    if recorder is not None:
+        recorder.capture(reset_step.observation)
+
+    policy_request = PolicyRequest(
+        policy_id=args.policy_id,
+        inference_parameters={"mode": "eval"},
+        actions_per_chunk=(
+            int(args.actions_per_chunk) if args.actions_per_chunk else None
+        ),
+    )
+
+    success = False
+    executed_steps = 0
+    chunk_index = 0
+    terminated = False
+    truncated = False
+    stall_counts: dict[str, int] = {}
+    recovery_activations = 0
+    while executed_steps < int(args.env_max_steps):
+        await session.renew_if_needed()
+
+        if not reviewed and recorder is None:
+            step = await session.policy_step(policy_request)
+            source = "vla"
+            selected_tool = None
+            # Atomic infer+execute: the actions never cross the wire.
+            submitted_actions = None
+            block_executed = int(step.executed_horizon) or 1
+            if step.observation is not None:
+                _append_jsonl(
+                    states_path,
+                    _state_row(
+                        list(step.observation.state),
+                        step_index=executed_steps + block_executed,
+                        chunk_index=chunk_index,
+                        step=step,
+                    ),
+                )
+        elif not reviewed:
+            # Capturing without frozen critic rules: still the pure-VLA
+            # baseline, but split into infer + submit so every simulator step
+            # yields an observation. Experiment A established that this does not
+            # change the physics.
+            proposal, _metadata = await session.policy_infer(policy_request)
+            block = [
+                [float(value) for value in row]
+                for row in proposal[: int(args.execute_horizon)]
+            ]
+            step, block_executed = await _execute_block(
+                session,
+                block,
+                recorder=recorder,
+                states_path=states_path,
+                first_step_index=executed_steps,
+                chunk_index=chunk_index,
+            )
+            source = "vla"
+            selected_tool = None
+            submitted_actions = block
+        else:
+            proposal, _metadata = await session.policy_infer(policy_request)
+            observation: dict[str, Any] = {"state": previous_state}
+            features = extract_robotwin_critic_features(
+                observation,
+                chunk_index=chunk_index,
+                executed_horizon=int(args.execute_horizon),
+                reward=0.0,
+                terminated=False,
+                truncated=False,
+                previous_state=previous_state,
+                stall_counts=stall_counts,
+            )
+            proposals = critic.evaluate(features, step_index=chunk_index)
+            decided = actor.decide_action(
+                task=args.task,
+                chunk_index=chunk_index,
+                observation=observation,
+                vla_actions=proposal,
+                features=features,
+                critic_proposals=proposals,
+                recovery_rules=recovery_rules,
+                environment_step=executed_steps,
+            )
+            if decided.decision is not None:
+                _append_jsonl(
+                    decisions_path,
+                    {
+                        "at": _now(),
+                        "chunk_index": chunk_index,
+                        "source": decided.source,
+                        **decided.decision.public_dict(),
+                    },
+                )
+            step, block_executed = await _execute_block(
+                session,
+                decided.actions,
+                recorder=recorder,
+                states_path=states_path,
+                first_step_index=executed_steps,
+                chunk_index=chunk_index,
+            )
+            source = decided.source
+            selected_tool = decided.selected_tool
+            submitted_actions = decided.actions
+            if controller is not None and controller.active:
+                if decided.source == "recovery":
+                    recovery_activations += 1
+                    controller.complete_current_step(
+                        selected_tool=selected_tool,
+                        environment_step=executed_steps,
+                        executed_horizon=int(step.executed_horizon),
+                        executed_arm=(
+                            decided.commanded_arms[0]
+                            if len(decided.commanded_arms) == 1
+                            else None
+                        ),
+                    )
+
+        row = _chunk_record(step, index=chunk_index)
+        row["source"] = source
+        row["selected_tool"] = selected_tool
+        row["step_index"] = executed_steps
+        # Stepwise submission returns `executed_horizon=1` on its last sub-step;
+        # the chunk row must carry what the whole block advanced, because
+        # `_make_events` derives `action_count` from exactly this field.
+        row["executed_horizon"] = block_executed
+        _append_jsonl(chunks_path, row)
+        _append_action_rows(
+            actions_path,
+            submitted_actions,
+            first_step_index=executed_steps,
+            source=source,
+        )
+        _append_jsonl(
+            tools_path,
+            {
+                "at": _now(),
+                "step_index": executed_steps,
+                "chunk_index": chunk_index,
+                "tool": selected_tool,
+                "source": source,
+                "proposal_only": source != "vla",
+                "environment_write": True,
+            },
+        )
+
+        if step.observation is not None:
+            observed = list(step.observation.state)
+            features_after = extract_robotwin_critic_features(
+                {"state": observed},
+                chunk_index=chunk_index,
+                executed_horizon=int(row["executed_horizon"] or 0),
+                reward=float(step.reward),
+                terminated=bool(step.terminated),
+                truncated=bool(step.truncated),
+                previous_state=previous_state,
+                stall_counts=stall_counts,
+            )
+            stall_counts = next_stall_counts(features_after)
+            previous_state = observed
+
+        executed_steps += int(row["executed_horizon"] or 0) or 1
+        chunk_index += 1
+        if row["success"]:
+            success = True
+        terminated = bool(step.terminated)
+        truncated = bool(step.truncated)
+        if terminated or truncated:
+            break
+
+    finished_at = _now()
+    artifact_index = {
+        "initial_observation_identity": initial_observation_identity,
+        "chunks": str(chunks_path),
+        "actions": str(actions_path),
+        "states": str(states_path),
+        "tool_events": str(tools_path),
+        "env_spec_digest": env_spec_digest,
+        "tool_catalog_digest": DEFAULT_ROBOTWIN_TOOL_CATALOG.digest,
+        "tool_binding_digest": binding.digest,
+        "arm_scoped_tools": list(binding.arm_scoped_tool_names),
+        "chunks_executed": chunk_index,
+        "steps_executed": executed_steps,
+        "terminated": terminated,
+        "truncated": truncated,
+        # Recorded on every episode: a RoboTwin diagnosis is chunk-granular and
+        # must never be compared like-for-like against a per-step family's.
+        "evidence_granularity": "chunk",
+        "execute_horizon": int(args.execute_horizon),
+        "baseline_mode": "pure_vla" if not reviewed else "critic_reviewed",
+        "role1_decider": type(decider).__name__ if reviewed else None,
+        "critic_rule_count": len(critic_rules),
+        "recovery_rule_count": len(recovery_rules),
+        "recovery_steps_executed": recovery_activations,
+        # gating._candidate_intervened reads this; without it the fallback looks
+        # for a "role1:"-prefixed key, which this family never writes (its key is
+        # "role1_decisions"), so every candidate episode would silently attest no
+        # intervention.  mechanism_diverged is then always False and the same-seed
+        # gate can never pass -- while its rationale claims "candidate never
+        # changed the failed parent action trajectory", which would be the wrong
+        # reason.  Counting executed recoveries rather than Role1 decisions is the
+        # stricter reading: a rejected proposal leaves the VLA chunk intact and
+        # changes no action.
+        "candidate_intervention": recovery_activations > 0,
+        # The dwell unit differs from every per-step family; a reader of this
+        # record must not have to infer it.
+        "dwell_semantics": describe_dwell_semantics(
+            execute_horizon=int(args.execute_horizon)
+        ),
+    }
+    if reviewed:
+        artifact_index["role1_decisions"] = str(decisions_path)
+    record = EpisodeRecord(
+        episode_id=args.episode_id or f"{args.logical_id}-{uuid.uuid4().hex[:8]}",
+        logical_id=args.logical_id,
+        generation=int(args.generation),
+        seed=int(args.seed),
+        policy_rng=int(args.policy_rng),
+        bundle_sha256=_optional_sha(args.bundle_sha256),
+        status="valid",
+        success=bool(success),
+        started_at=started_at,
+        finished_at=finished_at,
+        elapsed_s=time.monotonic() - started_monotonic,
+        artifact_index=artifact_index,
+        attempt_index=int(args.attempt_index),
+    )
+
+    # Index the trajectory and attach its failure segments: without them the
+    # campaign's Cluster stage has nothing to cluster and stalls silently
+    # (`cluster_failure_segments([])` returns `[]` rather than raising).
+    video_paths = recorder.encode() if recorder is not None else {}
+    analysis = index_episode_trajectory(
+        result=record,
+        artifacts=TrajectoryArtifacts(
+            chunks=chunks_path,
+            actions=actions_path,
+            states=states_path,
+            tools=tools_path,
+            videos=tuple(sorted(video_paths.values())),
+        ),
+    )
+    visual_evidence = _visual_evidence(
+        video_paths=video_paths,
+        states_path=states_path,
+        output_root=output_dir / "visual-evidence",
+        segments=analysis.segments,
+    )
+    record = dataclasses.replace(
+        record,
+        artifact_index={
+            **record.artifact_index,
+            "trajectory_index": (
+                analysis.index.as_dict() if analysis.index is not None else None
+            ),
+            "failure_segment_count": len(analysis.segments),
+            "videos": video_paths,
+            "visual_evidence": visual_evidence,
+        },
+        failure_segment=analysis.segments[0] if analysis.segments else None,
+        failure_segments=analysis.segments,
+    )
+
+    atomic_write_json(output_dir / "episode.json", record.as_dict())
+    if getattr(args, "result_file", None):
+        # How the campaign queue harvests the episode: the worker publishes the
+        # record at the path the job named, and `SubprocessRolloutExecutor`
+        # reads it back even if the worker later crashes.
+        atomic_write_json(args.result_file, record.as_dict(), overwrite=False)
+    return record
+
+
+async def run(args: argparse.Namespace, *, client: Any | None = None) -> EpisodeRecord:
+    """Run one episode against the shared rollout runtime.
+
+    The session is always closed, which is what returns the env slot to the
+    pool for the next rollout process.
+
+    Args:
+        args: Parsed CLI arguments.
+        client: Injected ``RemoteRuntimeClient``-shaped object; tests pass a
+            fake. When ``None`` this function owns the connection pool.
+
+    Returns:
+        The episode record.
+    """
+    owns_client = client is None
+    if client is None:
+        client = RemoteRuntimeClient(
+            args.runtime_url,
+            token=args.runtime_token,
+            operation_timeout_s=args.operation_timeout_s,
+            session_timeout_s=args.session_timeout_s,
+        )
+    session: RolloutSession | None = None
+    try:
+        handle = _single(
+            await client.create_sessions(
+                [
+                    CreateSessionRequest(
+                        application_id=RUNTIME_APPLICATION_ID,
+                        client_session_key=(
+                            f"{args.logical_id}-attempt-{args.attempt_index}"
+                        ),
+                        env_spec=_env_spec(args),
+                        default_policy_id=args.policy_id,
+                        lease_seconds=float(args.session_lease_s),
+                        metadata={
+                            "task": args.task,
+                            "seed": int(args.seed),
+                            "generation": int(args.generation),
+                            "logical_id": args.logical_id,
+                        },
+                    )
+                ]
+            ),
+            operation="create_sessions",
+        )
+        session = RolloutSession(
+            client,
+            handle.session_id,
+            lease_seconds=float(args.session_lease_s),
+            lease_expiration=float(handle.lease_expiration),
+        )
+        return await _run_episode(args, session, env_spec_digest=handle.env_spec_digest)
+    finally:
+        if session is not None and not session.closed:
+            closed = await session.close()
+            if closed.get("session_closed") is not True:
+                _append_jsonl(
+                    Path(args.output_dir) / "cleanup_errors.jsonl",
+                    {"at": _now(), "failure_class": closed.get("failure_class")},
+                )
+        if owns_client:
+            await client.aclose()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    Returns:
+        The configured parser.
+    """
+    parser = argparse.ArgumentParser(description="Run one frozen RoboTwin rollout")
+    parser.add_argument("--runtime-url", required=True)
+    parser.add_argument("--runtime-token", default=None)
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument("--task", default="adjust_bottle")
+    parser.add_argument(
+        "--assets-path",
+        required=True,
+        help="RoboTwin repository root (not its assets/ subdirectory)",
+    )
+    parser.add_argument("--embodiment", nargs="+", default=["aloha-agilex"])
+    parser.add_argument(
+        "--planner-backend", default="mplib", choices=["mplib", "curobo"]
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--policy-rng", type=int, default=0)
+    parser.add_argument("--generation", type=int, default=0)
+    parser.add_argument("--logical-id", required=True)
+    parser.add_argument("--episode-id", default=None)
+    parser.add_argument("--attempt-index", type=int, default=0)
+    parser.add_argument("--bundle-sha256", default=None)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--result-file",
+        default=None,
+        help="Where the campaign queue expects this episode's record",
+    )
+    parser.add_argument("--env-max-steps", type=int, default=200)
+    parser.add_argument("--execute-horizon", type=int, default=25)
+    parser.add_argument("--actions-per-chunk", type=int, default=None)
+    parser.add_argument("--env-pool-size", type=int, default=4)
+    parser.add_argument("--center-crop", action="store_true")
+    parser.add_argument(
+        "--capture-frames",
+        action="store_true",
+        help=(
+            "Submit each action separately so every simulator step yields an "
+            "observation, and encode one video per camera. Required for Stage 1: "
+            "a diagnosis needs at least three visual evidence items."
+        ),
+    )
+    parser.add_argument("--video-fps", type=int, default=20)
+    parser.add_argument(
+        "--role1-model",
+        default=None,
+        help=(
+            "Model identifier for a model-backed Role1; omit to use the "
+            "deterministic ArmAwareRole1 reference decider"
+        ),
+    )
+    parser.add_argument("--role1-planner", default="codex", choices=["api", "codex"])
+    parser.add_argument("--reasoning-effort", default="high")
+    parser.add_argument("--role1-max-tokens", type=int, default=4096)
+    parser.add_argument("--role1-timeout-s", type=int, default=600)
+    parser.add_argument("--role1-max-turns", type=int, default=2)
+    parser.add_argument(
+        "--bundle",
+        default="none",
+        help=(
+            "Path to the frozen CandidateBundle JSON a gate arm runs under. "
+            "The campaign substitutes {bundle_file}; Gen0 receives 'none'."
+        ),
+    )
+    parser.add_argument(
+        "--critic-rules",
+        default=None,
+        help="JSON list of frozen critic rules; enables the reviewed path",
+    )
+    parser.add_argument(
+        "--recovery-rules",
+        default=None,
+        help="JSON list of frozen recoveries; requires --critic-rules",
+    )
+    parser.add_argument("--session-lease-s", type=float, default=1800.0)
+    parser.add_argument("--operation-timeout-s", type=float, default=600.0)
+    parser.add_argument("--session-timeout-s", type=float, default=60.0)
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint.
+
+    Returns:
+        ``0`` when the episode completed, ``1`` when it did not.
+    """
+    args = build_parser().parse_args()
+    if int(args.execute_horizon) < 1:
+        raise SystemExit("--execute-horizon must be >= 1")
+    record = asyncio.run(run(args))
+    print(
+        json.dumps(
+            {
+                "episode_id": record.episode_id,
+                "success": record.success,
+                "elapsed_s": round(record.elapsed_s, 3),
+                "action_dim": ACTION_DIM,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0 if record.status == "valid" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robots/robotwin/tool_bindings.py
+++ b/robots/robotwin/tool_bindings.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Task bindings for the audited RoboTwin tool programs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from robots.robotwin.tool_catalog import (
+    DEFAULT_ROBOTWIN_TOOL_CATALOG,
+    ToolCatalog,
+    ToolSpec,
+)
+from zetta.evolution.jsonio import canonical_sha256
+
+
+@dataclass(frozen=True, slots=True)
+class TaskToolBinding:
+    """The frozen tool set one RoboTwin task may draw from.
+
+    Attributes:
+        task: RoboTwin task name.
+        tool_names: Every tool the task may use.
+        vla_tool_name: The action source; must be directly selectable.
+        candidate_tool_names: Tools a Stage-2 candidate may additionally bind.
+        privilege_mode: How privileged reads are authorised.
+        schema_version: Binding schema version.
+    """
+
+    task: str
+    tool_names: tuple[str, ...]
+    vla_tool_name: str = "robotwin.vla.pi05"
+    candidate_tool_names: tuple[str, ...] = ()
+    privilege_mode: str = "simulator_audited"
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        """Validate the binding against the catalog.
+
+        Raises:
+            ValueError: The binding is empty, self-inconsistent, or references
+                a tool the catalog does not declare.
+        """
+        if not self.task or not self.tool_names:
+            raise ValueError("task binding requires a task and at least one tool")
+        if len(set(self.tool_names)) != len(self.tool_names):
+            raise ValueError("task binding contains duplicate tools")
+        if self.vla_tool_name not in self.tool_names:
+            raise ValueError("task binding VLA tool must be directly selectable")
+        if not set(self.candidate_tool_names).issubset(self.tool_names):
+            raise ValueError("candidate-only tools must belong to the task binding")
+        unknown = set(self.tool_names) - set(DEFAULT_ROBOTWIN_TOOL_CATALOG.names())
+        if unknown:
+            raise ValueError(
+                f"task binding references unknown tools: {sorted(unknown)}"
+            )
+
+    def public_dict(self) -> dict[str, Any]:
+        """Return the stable representation hashed into the manifest.
+
+        Returns:
+            A JSON-friendly dict.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "task": self.task,
+            "tool_names": list(self.tool_names),
+            "vla_tool_name": self.vla_tool_name,
+            "candidate_tool_names": list(self.candidate_tool_names),
+            "privilege_mode": self.privilege_mode,
+        }
+
+    @property
+    def digest(self) -> str:
+        """The binding's content hash.
+
+        Returns:
+            A hex sha256 over :meth:`public_dict`.
+        """
+        return canonical_sha256(self.public_dict())
+
+    @property
+    def arm_scoped_tool_names(self) -> tuple[str, ...]:
+        """The bound tools that require an ``arm`` argument.
+
+        Returns:
+            Names in catalog order.
+        """
+        selected = set(self.tool_names)
+        return tuple(
+            name
+            for name in DEFAULT_ROBOTWIN_TOOL_CATALOG.arm_scoped_names()
+            if name in selected
+        )
+
+    def select(
+        self, catalog: ToolCatalog = DEFAULT_ROBOTWIN_TOOL_CATALOG
+    ) -> tuple[ToolSpec, ...]:
+        """Resolve the binding into declarations.
+
+        Args:
+            catalog: The catalog to resolve against.
+
+        Returns:
+            The bound declarations.
+        """
+        return catalog.select(allow=self.tool_names)
+
+
+_COMMON = (
+    "robotwin.observation.view_driver_state",
+    "robotwin.camera.view_meta",
+    "robotwin.vla.pi05",
+    "robotwin.verify.state",
+)
+"""Tools every RoboTwin task binding includes."""
+
+
+TASK_BINDINGS = {
+    "adjust_bottle": TaskToolBinding(
+        task="adjust_bottle",
+        # The task is defined as "lift the bottle with the *correct* arm and
+        # keep it upright", so arm selection is not incidental here -- it is the
+        # thing being judged. The binding therefore carries the whole arm-scoped
+        # group rather than a single-arm subset.
+        tool_names=tuple(
+            sorted(
+                {
+                    *_COMMON,
+                    "robotwin.arm.select",
+                    "robotwin.arm.read_joint_state",
+                    "robotwin.control.hold_arm",
+                    "robotwin.gripper.set",
+                    "robotwin.critic.temporal_engagement",
+                }
+            )
+        ),
+        candidate_tool_names=(
+            "robotwin.control.hold_arm",
+            "robotwin.critic.temporal_engagement",
+            "robotwin.gripper.set",
+        ),
+    ),
+}
+"""Audited bindings, keyed by RoboTwin task name."""
+
+
+def binding_for_task(task: str) -> TaskToolBinding:
+    """Resolve an explicit task binding; unknown tasks fail closed.
+
+    Args:
+        task: The RoboTwin task name.
+
+    Returns:
+        The audited binding.
+
+    Raises:
+        KeyError: No binding has been audited for this task.
+    """
+    try:
+        return TASK_BINDINGS[task]
+    except KeyError as exc:
+        raise KeyError(
+            f"no audited tool binding exists for RoboTwin task {task!r}"
+        ) from exc

--- a/robots/robotwin/tool_catalog.py
+++ b/robots/robotwin/tool_catalog.py
@@ -1,0 +1,434 @@
+# Copyright (c) 2026 Zetta Contributors
+"""RoboTwin tool declarations implemented in this repository.
+
+A tool declaration never grants ownership of the simulator: control tools only
+propose actions or plans for the single environment actor to review and execute.
+
+The one structural difference from the single-arm catalogs is
+:attr:`ToolSpec.arm_scoped`. RoboTwin is bimanual, so a tool that moves an arm
+has to say *which* arm, and "which arm" cannot be a documentation convention:
+this catalog is content-hashed into a campaign manifest
+(:meth:`ToolCatalog.digest`) and cannot be edited once a campaign is running.
+Making it a declared, hashed field means a candidate writer that omits the
+``arm`` argument fails against the schema instead of silently driving whichever
+hand the implementation happened to pick.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Literal
+
+from robots.robotwin.action_contract import ARMS
+
+RiskLevel = Literal["low", "medium", "high"]
+
+TOOL_NAMESPACE = "robotwin."
+"""Every tool in this catalog lives under one namespace."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    """Serialize deterministically for hashing.
+
+    Args:
+        value: A JSON-compatible value.
+
+    Returns:
+        Canonical UTF-8 bytes.
+    """
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Immutable public contract for one clean-room RoboTwin tool.
+
+    Attributes:
+        name: Fully qualified tool name under :data:`TOOL_NAMESPACE`.
+        description: One-line human-readable contract.
+        capabilities: Capability tags used for selection.
+        risk: Declared risk level.
+        privileged: Whether the tool reads privileged simulator state.
+        privileged_fields: The privileged fields it may read.
+        proposal_only: Whether it may only propose, never act.
+        arm_scoped: Whether an invocation must carry an ``arm`` argument. True
+            for anything that moves or inspects a specific hand.
+        service: Whether it is served over HTTP.
+        local: Whether it runs in-process.
+        endpoint_env: Environment variable naming the service endpoint.
+        service_path: HTTP path for a service tool.
+    """
+
+    name: str
+    description: str
+    capabilities: tuple[str, ...]
+    risk: RiskLevel = "low"
+    privileged: bool = False
+    privileged_fields: tuple[str, ...] = ()
+    proposal_only: bool = False
+    arm_scoped: bool = False
+    service: bool = False
+    local: bool = True
+    endpoint_env: str | None = None
+    service_path: str = "/infer"
+
+    def __post_init__(self) -> None:
+        """Validate the declaration.
+
+        Raises:
+            ValueError: Any field violates the catalog contract.
+        """
+        if not self.name.startswith(TOOL_NAMESPACE):
+            raise ValueError(f"tool names must start with {TOOL_NAMESPACE!r}")
+        if not self.description.strip():
+            raise ValueError("tool description must not be empty")
+        if not self.capabilities:
+            raise ValueError("tool capabilities must not be empty")
+        if self.service == self.local:
+            raise ValueError("a tool must be exactly one of service or local")
+        if self.service and not self.endpoint_env:
+            raise ValueError("service tools require an endpoint environment name")
+        if self.local and self.endpoint_env is not None:
+            raise ValueError("local tools cannot declare a service endpoint")
+        if self.privileged_fields and not self.privileged:
+            raise ValueError("privileged_fields require privileged=True")
+        if self.risk not in {"low", "medium", "high"}:
+            raise ValueError("invalid risk level")
+        object.__setattr__(self, "capabilities", tuple(sorted(set(self.capabilities))))
+        object.__setattr__(
+            self, "privileged_fields", tuple(sorted(set(self.privileged_fields)))
+        )
+
+    def public_dict(self) -> dict[str, Any]:
+        """Return the stable, secret-free representation used for hashing.
+
+        Returns:
+            A JSON-friendly dict; ``arm_scoped`` is part of the hash, so
+            changing a tool's arm requirement changes the catalog digest.
+        """
+        return {
+            "name": self.name,
+            "description": self.description,
+            "capabilities": list(self.capabilities),
+            "risk": self.risk,
+            "privileged": self.privileged,
+            "privileged_fields": list(self.privileged_fields),
+            "proposal_only": self.proposal_only,
+            "arm_scoped": self.arm_scoped,
+            "service": self.service,
+            "local": self.local,
+            "endpoint_env": self.endpoint_env,
+            "service_path": self.service_path,
+        }
+
+    def validate_arguments(self, arguments: Mapping[str, Any]) -> str | None:
+        """Check an invocation's arm argument against the declaration.
+
+        Args:
+            arguments: The proposed tool arguments.
+
+        Returns:
+            The canonical arm selector for an arm-scoped tool, else ``None``.
+
+        Raises:
+            ValueError: An arm-scoped tool was invoked without a usable ``arm``,
+                or a non-arm-scoped tool was given one.
+        """
+        from robots.robotwin.action_contract import normalize_arm
+
+        supplied = arguments.get("arm")
+        if not self.arm_scoped:
+            if supplied is not None:
+                raise ValueError(
+                    f"{self.name} is not arm-scoped but was given arm={supplied!r}"
+                )
+            return None
+        if supplied is None:
+            raise ValueError(
+                f"{self.name} is arm-scoped: the invocation must name an arm "
+                f"({', '.join(ARMS)}, or 'both')"
+            )
+        return normalize_arm(str(supplied))
+
+
+class ToolCatalog:
+    """An immutable, content-hashed set of tool declarations."""
+
+    def __init__(self, specs: Iterable[ToolSpec]) -> None:
+        """Index and hash the declarations.
+
+        Args:
+            specs: The tool declarations.
+
+        Raises:
+            ValueError: The catalog is empty or contains duplicate names.
+        """
+        indexed: dict[str, ToolSpec] = {}
+        for spec in specs:
+            if spec.name in indexed:
+                raise ValueError(f"duplicate tool declaration: {spec.name}")
+            indexed[spec.name] = spec
+        if not indexed:
+            raise ValueError("tool catalog must not be empty")
+        self._specs: Mapping[str, ToolSpec] = MappingProxyType(
+            dict(sorted(indexed.items()))
+        )
+        self._digest = hashlib.sha256(
+            _canonical_json([item.public_dict() for item in self._specs.values()])
+        ).hexdigest()
+
+    @property
+    def digest(self) -> str:
+        """The catalog's content hash.
+
+        Returns:
+            A hex sha256 over every declaration.
+        """
+        return self._digest
+
+    def names(self) -> tuple[str, ...]:
+        """List the declared tool names.
+
+        Returns:
+            Names in sorted order.
+        """
+        return tuple(self._specs)
+
+    def get(self, name: str) -> ToolSpec:
+        """Look up one declaration.
+
+        Args:
+            name: The tool name.
+
+        Returns:
+            The declaration.
+
+        Raises:
+            KeyError: The tool is not declared.
+        """
+        try:
+            return self._specs[name]
+        except KeyError as exc:
+            raise KeyError(f"unknown robot tool: {name}") from exc
+
+    def select(
+        self,
+        *,
+        allow: Iterable[str] | None = None,
+        deny: Iterable[str] = (),
+        capabilities: Iterable[str] = (),
+    ) -> tuple[ToolSpec, ...]:
+        """Select tools deterministically; unknown policy names fail closed.
+
+        Args:
+            allow: Names to allow; ``None`` allows everything declared.
+            deny: Names to exclude.
+            capabilities: When non-empty, keep only tools sharing a capability.
+
+        Returns:
+            The selected declarations, in catalog order.
+
+        Raises:
+            KeyError: A policy names a tool this catalog does not declare.
+        """
+        allowed = set(self._specs) if allow is None else set(allow)
+        denied = set(deny)
+        unknown = (allowed | denied) - set(self._specs)
+        if unknown:
+            raise KeyError(f"unknown RoboTwin tools in policy: {sorted(unknown)}")
+        required = set(capabilities)
+        return tuple(
+            spec
+            for name, spec in self._specs.items()
+            if name in allowed
+            and name not in denied
+            and (not required or required.intersection(spec.capabilities))
+        )
+
+    def arm_scoped_names(self) -> tuple[str, ...]:
+        """List the tools that require an ``arm`` argument.
+
+        Returns:
+            Names in catalog order.
+        """
+        return tuple(name for name, spec in self._specs.items() if spec.arm_scoped)
+
+    def public_dict(self) -> dict[str, Any]:
+        """Return the catalog's frozen public form.
+
+        Returns:
+            A JSON-friendly dict carrying the digest and every declaration.
+        """
+        return {
+            "schema_version": 1,
+            "digest": self.digest,
+            "tools": [spec.public_dict() for spec in self._specs.values()],
+        }
+
+
+def _local(
+    name: str,
+    description: str,
+    *capabilities: str,
+    risk: RiskLevel = "low",
+    privileged: bool = False,
+    privileged_fields: tuple[str, ...] = (),
+    proposal_only: bool = False,
+    arm_scoped: bool = False,
+) -> ToolSpec:
+    """Declare an in-process tool.
+
+    Args:
+        name: Tool name.
+        description: One-line contract.
+        *capabilities: Capability tags.
+        risk: Risk level.
+        privileged: Whether it reads privileged state.
+        privileged_fields: The privileged fields it may read.
+        proposal_only: Whether it may only propose.
+        arm_scoped: Whether it requires an ``arm`` argument.
+
+    Returns:
+        The declaration.
+    """
+    return ToolSpec(
+        name=name,
+        description=description,
+        capabilities=capabilities,
+        risk=risk,
+        privileged=privileged,
+        privileged_fields=privileged_fields,
+        proposal_only=proposal_only,
+        arm_scoped=arm_scoped,
+        local=True,
+        service=False,
+    )
+
+
+def _service(
+    name: str,
+    description: str,
+    endpoint_env: str,
+    *capabilities: str,
+    risk: RiskLevel = "medium",
+    proposal_only: bool = True,
+    arm_scoped: bool = False,
+    service_path: str = "/infer",
+) -> ToolSpec:
+    """Declare an HTTP-served tool.
+
+    Args:
+        name: Tool name.
+        description: One-line contract.
+        endpoint_env: Environment variable naming the endpoint.
+        *capabilities: Capability tags.
+        risk: Risk level.
+        proposal_only: Whether it may only propose.
+        arm_scoped: Whether it requires an ``arm`` argument.
+        service_path: HTTP path.
+
+    Returns:
+        The declaration.
+    """
+    return ToolSpec(
+        name=name,
+        description=description,
+        capabilities=capabilities,
+        risk=risk,
+        proposal_only=proposal_only,
+        arm_scoped=arm_scoped,
+        local=False,
+        service=True,
+        endpoint_env=endpoint_env,
+        service_path=service_path,
+    )
+
+
+def build_robotwin_tool_catalog() -> ToolCatalog:
+    """Build the RoboTwin tool catalog.
+
+    Deliberately small. This is the set an ``adjust_bottle`` campaign needs, not
+    a port of the RoboCasa catalog: roughly a third of that one is specific to a
+    dishwasher, and a declaration that no implementation backs is worse than a
+    missing one -- it is hashed into the manifest either way.
+
+    Returns:
+        The frozen catalog.
+    """
+    specs = (
+        _local(
+            "robotwin.observation.view_driver_state",
+            "Read the 14-dim joint state and image references without advancing "
+            "the simulator.",
+            "perception.observe",
+        ),
+        _local(
+            "robotwin.camera.view_meta",
+            "Inspect image dimensions for the head and both wrist cameras.",
+            "perception.camera_metadata",
+        ),
+        _local(
+            "robotwin.arm.select",
+            "Choose which arm should act next, given the target's position "
+            "relative to the two grippers.",
+            "planning.arm_selection",
+            proposal_only=True,
+        ),
+        _local(
+            "robotwin.arm.read_joint_state",
+            "Read one arm's 6 joint angles and gripper opening.",
+            "perception.joint_state",
+            arm_scoped=True,
+        ),
+        _local(
+            "robotwin.control.hold_arm",
+            "Repeat one arm's measured joint targets so it holds position while "
+            "the other arm acts. Required because RoboTwin consumes absolute "
+            "targets: a zero vector commands every joint to angle zero.",
+            "control.hold",
+            arm_scoped=True,
+            proposal_only=True,
+        ),
+        _local(
+            "robotwin.gripper.set",
+            "Propose a normalized gripper opening for one arm.",
+            "control.gripper",
+            arm_scoped=True,
+            proposal_only=True,
+        ),
+        _local(
+            "robotwin.vla.pi05",
+            "Sample a bimanual action chunk from the Pi0.5 RoboTwin policy.",
+            "control.vla_chunk",
+            risk="medium",
+            proposal_only=True,
+        ),
+        _local(
+            "robotwin.verify.state",
+            "Compare the observed joint state against an expected pose within a "
+            "tolerance.",
+            "verification.state",
+        ),
+        _local(
+            "robotwin.critic.temporal_engagement",
+            "Report whether the commanded arm has made progress over a bounded "
+            "window of chunk-final frames.",
+            "critic.temporal",
+            arm_scoped=True,
+            proposal_only=True,
+        ),
+    )
+    return ToolCatalog(specs)
+
+
+DEFAULT_ROBOTWIN_TOOL_CATALOG = build_robotwin_tool_catalog()
+"""The catalog every RoboTwin campaign freezes into its manifest."""

--- a/rollout_runtime/backends/__init__.py
+++ b/rollout_runtime/backends/__init__.py
@@ -8,12 +8,11 @@ never modified**. ``robocasa_current`` / ``groot_policy`` do not touch rlinf
 at all; they depend only on the current branch's
 ``robots.robocasa.session_core`` / ``groot_core``.
 
-Landing order: ``fake`` -> ``libero`` -> ``maniskill``. The originally
-planned fourth step was ``robotwin`` (the only all-rlinf family that is
-``final_only``, useful for exercising the ``obs_list`` length normalization),
-but its package does not exist in any of the verified runtime images, so it
-remains "declared but not implemented" (see the runtime validation notes for
-details).
+Landing order: ``fake`` -> ``libero`` -> ``maniskill`` -> ``robocasa`` ->
+``robotwin``. ``robotwin`` is the only ``final_only`` family and therefore the
+one that actually exercises the ``obs_list`` length normalization; its adapter
+is ``rlinf_robotwin.py``, driving the vendored
+``zetta.envs.robotwin.environment.RoboTwinEnv``.
 
 The ``robocasa`` family, as part of the Rollout Runtime v3 migration, switches
 to the current branch's ``RoboCasaSession``/GR00T business logic; the source
@@ -41,18 +40,18 @@ __all__ = [
     "register_env_family_for",
 ]
 
-ENV_BACKENDS = ("fake", "libero", "maniskill", "robocasa")
+ENV_BACKENDS = ("fake", "libero", "maniskill", "robocasa", "robotwin")
 """Env families that actually have an adapter in this build.
 
-``robotwin`` **has a declaration in ``ENV_FAMILY_BEHAVIORS`` but no
-adapter**: its ``robotwin`` package does not exist in any verified runtime
-image, so it remains "declared but not implemented," and
-``get_env_family`` returns an explicit ``UNSUPPORTED_ENV_SPEC`` with
-``declared=True``.
+Every family declared in ``ENV_FAMILY_BEHAVIORS`` now ships an adapter. The
+"declared but not implemented" path in ``get_env_family`` is still live -- it
+is what a future declaration-first family would hit -- but nothing takes it
+today.
 
-``robocasa`` is likewise not yet registered here: a new
-``robocasa_current.py`` (``EnvExecutionCore``, wrapping the current branch's
-``RoboCasaSession``) will be added later.
+``robotwin`` additionally needs the ``robotwin`` package and its ~30 GB asset
+bundle at **run** time; that is a deployment prerequisite, not a build one, so
+the family is registered unconditionally and a missing package surfaces as an
+``ENV_FAILURE`` from ``build`` rather than as a missing family.
 """
 
 POLICY_BACKENDS = ("fake", "zetta_openpi", "groot", "cosmos_lite")
@@ -92,6 +91,12 @@ def register_env_family_for(env_family: str) -> Any:
         )
 
         return register_robocasa_current_env_family(replace=True)
+    if env_family == "robotwin":
+        from rollout_runtime.backends.rlinf_robotwin import (
+            register_robotwin_env_family,
+        )
+
+        return register_robotwin_env_family(replace=True)
     raise RuntimeApiError(
         make_error(
             ErrorCode.UNSUPPORTED_ENV_SPEC,

--- a/rollout_runtime/backends/rlinf_policy.py
+++ b/rollout_runtime/backends/rlinf_policy.py
@@ -149,6 +149,12 @@ class RlinfPolicyConfig:
         dtype: Compute precision name; ``None`` means infer from ``precision``.
         unnorm_key: Action denormalization key (needed for openvla family;
             ignored by openpi).
+        stack_wrist_views: Whether to re-stack ``wrist_images`` and
+            ``extra_view_images`` into one ``[B, N_IMG, H, W, C]`` tensor before
+            the forward pass. Required by the ALOHA pipeline, which reads the
+            left and right wrist as ``wrist_images[0]`` / ``wrist_images[1]``
+            and ignores ``extra_view_image`` entirely; see
+            :func:`_stack_wrist_views`.
     """
 
     model_type: str = "openpi"
@@ -187,6 +193,7 @@ class RlinfPolicyConfig:
     device: str = "cuda"
     dtype: str | None = None
     unnorm_key: str = ""
+    stack_wrist_views: bool = False
 
     @classmethod
     def from_mapping(cls, config: Mapping[str, Any] | None) -> RlinfPolicyConfig:
@@ -555,6 +562,8 @@ class RlinfPolicyCore:
                     f"{index}; compat_key should have separated them"
                 )
         env_obs = observations_to_env_output(observations)
+        if self.config.stack_wrist_views:
+            env_obs = _stack_wrist_views(env_obs)
         instructions = list(env_obs["task_descriptions"])
         for index, request in enumerate(requests):
             if request.instruction_override:
@@ -619,6 +628,53 @@ class RlinfPolicyCore:
                 model_type=self.config.model_type,
             ),
         )
+
+
+def _stack_wrist_views(env_obs: dict[str, Any]) -> dict[str, Any]:
+    """Re-stack the wrist views into the single ``[B, N_IMG, H, W, C]`` tensor.
+
+    The rlinf 5-key schema allows ``wrist_images`` to be either
+    ``[N_ENV, H, W, C]`` or ``[N_ENV, N_IMG, H, W, C]``
+    (``rlinf/data/schema/embodied_types.py::prepare_observations``), and the
+    ALOHA pipeline **requires** the second form: ``aloha_policy._decode_aloha``
+    indexes ``wrist_images[0]`` as the left wrist and ``wrist_images[1]`` as the
+    right one, and never reads ``observation/extra_view_image`` at all.
+
+    The Runtime's ``Observation`` cannot carry that form -- ``wrist_image`` is a
+    single ``PayloadRef`` -- so a bimanual family splits its two wrists across
+    ``wrist_image`` (left) and ``extra_view_images[0]`` (right), and this
+    function is the exact inverse, applied just before the model sees the batch.
+    The split and this re-stack are a matched pair; changing one without the
+    other silently feeds the model a mangled wrist tensor rather than raising
+    (RoboTwin's first hardware run produced a
+    ``expected input[2, 224, 224, 224] to have 3 channels`` deep inside the
+    vision tower).
+
+    A no-op when there is nothing to stack, so it is safe to leave enabled for a
+    single-wrist configuration.
+
+    Args:
+        env_obs: The five-key batch dict from ``observations_to_env_output``.
+
+    Returns:
+        A shallow copy with ``wrist_images`` stacked and ``extra_view_images``
+        cleared; the input unchanged when either view is absent.
+    """
+    wrist = env_obs.get("wrist_images")
+    extra = env_obs.get("extra_view_images")
+    if wrist is None or extra is None:
+        return env_obs
+    wrist_array = np.asarray(wrist)
+    extra_array = np.asarray(extra)
+    if wrist_array.ndim == 4:
+        # [B, H, W, C] -> [B, 1, H, W, C]
+        wrist_array = wrist_array[:, None, ...]
+    if extra_array.ndim == 4:
+        extra_array = extra_array[:, None, ...]
+    stacked = dict(env_obs)
+    stacked["wrist_images"] = np.concatenate([wrist_array, extra_array], axis=1)
+    stacked["extra_view_images"] = None
+    return stacked
 
 
 def _pad_batch(array: np.ndarray, batch_size: int) -> np.ndarray:

--- a/rollout_runtime/backends/rlinf_robotwin.py
+++ b/rollout_runtime/backends/rlinf_robotwin.py
@@ -1,0 +1,1158 @@
+# Copyright (c) 2026 Zetta Contributors
+"""RoboTwin 2.0 family adapter.
+
+**Does not reimplement the env**: ``zetta.envs.robotwin.environment.RoboTwinEnv``
+(vendored from RLinf ``9ad44393``) is driven as-is. This module translates the
+Runtime's session/slot semantics into family calls and normalizes the family's
+output through ``core.env_execution.normalize_chunk_outcome``, the single exit
+point.
+
+Its points of divergence from the other rlinf families -- all of them purely
+**declarative**, so nothing upstream needs an ``if env_family == ...``:
+
+1. ``chunk_obs_layout="final_only"``. RoboTwin is the **only** such family.
+   ``RoboTwinEnv.chunk_step`` hands the whole chunk to ``venv.step`` in one call
+   and returns an ``obs_list`` of length 1 no matter how long the chunk was, so
+   this adapter calls the family's own ``chunk_step`` rather than stepping lane
+   by lane the way libero/maniskill do. The consequence is real and deliberate
+   (see D7 in ``plan/robotwin_support_plan.md``): there are **no intermediate
+   frames**, so ``ChunkOutcome.per_step`` is ``None`` and Cluster/Diagnose
+   evidence is chunk-granular rather than step-granular.
+2. ``reset_signature="env_idx_env_seeds"``: ``reset(env_idx, env_seeds)``, with
+   the seed list carrying the *scene* identity. RoboTwin's seed **is** its
+   reset-state id, so unlike maniskill this family declares
+   ``supports_reset_state_id=True`` -- and that declaration is load-bearing,
+   because the campaign protocol's held-out seed discipline depends on being
+   able to pin an exact scene.
+3. ``action_layout="numpy_env_chunk_dim"`` at 14 dims (ALOHA bimanual:
+   6 joints + 1 gripper per arm), not 7.
+4. ``device_kind="cpu_subproc"`` **with** ``needs_accelerator_override=True``:
+   ``VectorEnv`` is a plain multiprocessing pool, not a batched-GPU-tensor
+   family, but SAPIEN rendering will not initialise without a GPU (a container
+   lacking the ``graphics`` driver capability fails with
+   ``failed to find a rendering device``). Same shape as RoboCasa's override.
+5. ``per_slot`` only: ``VectorEnv`` already owns its own subprocess fan-out, so
+   there is no second "several lanes in one process" form to expose.
+6. **Wrist unstacking (D1).** The family stacks left/right wrist frames into one
+   ``[num_envs, n, H, W, C]`` ``wrist_images`` tensor, while the Runtime's
+   ``Observation`` has a single ``wrist_image`` plus ``extra_view_images``. The
+   split happens here: left wrist -> ``wrist_image``, right wrist ->
+   ``extra_view_images[0]``. The mapping is driven by the family's
+   ``wrist_image_names``, never by position, and it enters ``obs_schema_digest``
+   -- so getting it wrong does not raise, it silently feeds the policy a
+   mirrored view. ``tests/runtime/test_robotwin_family.py`` pins it.
+7. **Open-loop execute horizon (D3).** ``num_action_chunks`` for the published
+   RoboTwin Pi0.5 checkpoint is 50, and with ``final_only`` that would mean one
+   observation per 50 simulator steps -- too coarse for the runtime Critic to
+   attribute anything. ``execute_horizon`` submits only the first N actions of
+   each chunk and discards the rest, which is ordinary open-loop replanning: the
+   model is untouched, and more frequent replanning generally helps rather than
+   hurts.
+
+Dependency surface: the vendored env + ``robotwin`` + SAPIEN + torch + numpy,
+all **lazily imported inside functions**.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from rollout_runtime.api.enums import ErrorCode
+from rollout_runtime.api.errors import RuntimeApiError, make_error
+from rollout_runtime.api.messages import (
+    EnvFamilyCapability,
+    EnvSpecMsg,
+    Observation,
+    ResetSpec,
+)
+from rollout_runtime.backends.rlinf_family import (
+    LaneState,
+    LaneStatus,
+    lane_statuses,
+    observation_from_payload,
+    to_numpy,
+)
+from rollout_runtime.core.env_execution import (
+    PER_SLOT_FORM,
+    ChunkOutcome,
+    EnvFamilyBehavior,
+    normalize_chunk_outcome,
+)
+from rollout_runtime.core.env_registry import (
+    ROBOTWIN_ENV_FAMILY,
+    behavior_for,
+    capability_from_behavior,
+    register_env_family,
+    requested_core_form,
+)
+
+__all__ = [
+    "ROBOTWIN_ENV_FAMILY",
+    "RobotwinEnvConfig",
+    "RobotwinEnvCore",
+    "RobotwinEnvFamily",
+    "register_robotwin_env_family",
+    "robotwin_env_capability",
+]
+
+ROBOTWIN_ACTION_DIM = 14
+"""ALOHA bimanual action width: 6 joints + 1 gripper, per arm."""
+
+LEFT_WRIST_KEY = "left_wrist_image"
+"""The family's name for the frame that becomes ``Observation.wrist_image``."""
+
+RIGHT_WRIST_KEY = "right_wrist_image"
+"""The family's name for the frame that becomes ``extra_view_images[0]``."""
+
+
+@dataclasses.dataclass
+class RobotwinEnvConfig:
+    """RoboTwin family private config (corresponds to ``EnvSpecMsg.env_config``).
+
+    Field names follow RLinf's ``env/robotwin_*.yaml`` so a published RLinf
+    experiment can be transcribed without renaming anything.
+
+    Attributes:
+        task_name: RoboTwin task id, e.g. ``adjust_bottle``.
+        embodiment: RoboTwin embodiment spec. A one-element list picks a single
+            dual-arm robot (``["aloha-agilex"]``); a three-element list picks
+            two arms plus their separation (``["piper", "piper", 0.6]``).
+        assets_path: The RoboTwin **repository root**. Not its ``assets/``
+            subdirectory -- RoboTwin joins ``assets/...`` onto this internally,
+            and pointing at the subdirectory yields a confusing
+            ``.../assets/assets/...`` ``FileNotFoundError``.
+        seeds_path: Optional curated success-seed JSON. When present the family
+            draws reset seeds from it instead of sampling; explicit seeds in a
+            ``ResetSpec`` still win over both.
+        planner_backend: ``mplib`` or ``curobo``. ``mplib`` is the default here
+            rather than RoboTwin's own ``curobo`` default: curobo needs a CUDA
+            toolchain to build, RLinf's own RoboTwin configs all select mplib,
+            and the validated image ships no curobo at all.
+        step_lim: RoboTwin's internal per-task planning step limit.
+        max_episode_steps: Outer truncation horizon, checked by the family
+            against its own elapsed-step counter.
+        center_crop: Whether to centre-crop and resize frames to 224x224.
+            RoboTwin's cameras deliver 240x320, so this is also the resolution
+            switch.
+        collect_head_camera: Whether the head camera is rendered.
+        collect_wrist_camera: Whether both wrist cameras are rendered. Off means
+            ``wrist_image``/``extra_view_images`` come back empty.
+        head_camera_type: Camera model for the head view.
+        wrist_camera_type: Camera model for the wrist views.
+        domain_randomization: RoboTwin's randomization block, passed through
+            verbatim.
+        reward_coef: Scale applied by the family's custom reward.
+        use_custom_reward: Whether to derive reward from the termination flag
+            rather than the environment's own.
+        use_rel_reward: Whether the custom reward is a per-step difference.
+        ignore_terminations: Whether to force termination flags to false and run
+            a fixed horizon. RLinf's published eval sets this, which is why its
+            reported ``episode_len`` is always the full horizon.
+        auto_reset: Whether the family may reset itself. The Runtime drives
+            resets through sessions, so this is fixed to false.
+        use_fixed_reset_state_ids: Whether the family pins its own reset-state
+            pool.
+        is_eval: The family's eval flag; only consulted on its auto-reset path.
+        group_size: rlinf's group replication; the Runtime binds one session per
+            lane, so this is fixed to 1.
+        seed: Family base seed; the effective seed still adds ``seed_offset``.
+        action_dim: Action width; must be 14.
+        chunk_size: Declared chunk length (actual execution follows the supplied
+            actions and ``execute_horizon``).
+        execute_horizon: How many actions of each chunk to actually submit;
+            ``None`` submits all of them. See divergence 7.
+        action_model_type: Model type recorded for ``prepare_actions``.
+        save_video: Whether the family writes video.
+        video_base_dir: Where the family writes video when enabled.
+        teardown_on_close: Whether ``close`` really tears the SAPIEN pool down.
+            Off by default because that teardown **segfaults**; see
+            :meth:`RobotwinEnvCore.close`. Turn it on only against a RoboTwin
+            build where the crash is fixed.
+        core_form: Execution core form; only ``per_slot`` is declared.
+        extra_task_config: Extra keys merged into RoboTwin's ``task_config``.
+    """
+
+    task_name: str = "adjust_bottle"
+    embodiment: list[Any] = dataclasses.field(default_factory=lambda: ["aloha-agilex"])
+    assets_path: str = ""
+    seeds_path: str | None = None
+    planner_backend: str = "mplib"
+    step_lim: int = 200
+    max_episode_steps: int = 200
+    center_crop: bool = False
+    collect_head_camera: bool = True
+    collect_wrist_camera: bool = True
+    head_camera_type: str = "D435"
+    wrist_camera_type: str = "D435"
+    domain_randomization: dict[str, Any] = dataclasses.field(default_factory=dict)
+    reward_coef: float = 1.0
+    use_custom_reward: bool = True
+    use_rel_reward: bool = False
+    ignore_terminations: bool = False
+    auto_reset: bool = False
+    use_fixed_reset_state_ids: bool = False
+    is_eval: bool = True
+    group_size: int = 1
+    seed: int = 0
+    action_dim: int = ROBOTWIN_ACTION_DIM
+    chunk_size: int = 16
+    execute_horizon: int | None = None
+    action_model_type: str = "openpi"
+    save_video: bool = False
+    video_base_dir: str = "/tmp/rr_robotwin_video"
+    teardown_on_close: bool = False
+    core_form: str = PER_SLOT_FORM
+    extra_task_config: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any] | None) -> RobotwinEnvConfig:
+        """Construct a config from an ``env_config`` dict.
+
+        Unknown keys are rejected rather than ignored: ``env_config`` feeds
+        ``EnvSpecMsg.digest()``, so a typo would silently allocate a second
+        pool -- and for RoboTwin a pool is a set of SAPIEN subprocesses plus
+        their share of a hard GPU memory budget, which is far worse to diagnose
+        than an error.
+
+        Args:
+            config: The family-private config; ``None`` means all defaults.
+
+        Returns:
+            The structured config.
+
+        Raises:
+            RuntimeApiError: An unknown key is present, or a value violates a
+                family invariant (``INVALID_ARGUMENT``).
+        """
+        if not config:
+            return cls()
+        known = {field.name for field in dataclasses.fields(cls)}
+        unknown = sorted(key for key in config if key not in known)
+        if unknown:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"unknown robotwin env config keys: {unknown}",
+                    unknown_keys=unknown,
+                    known_keys=sorted(known),
+                )
+            )
+        instance = cls(**dict(config))
+        instance._validate()
+        return instance
+
+    def _validate(self) -> None:
+        """Check the family invariants.
+
+        Raises:
+            RuntimeApiError: ``group_size`` is not 1, ``action_dim`` is not 14,
+                ``execute_horizon`` is not positive, or ``assets_path`` is
+                missing (``INVALID_ARGUMENT``).
+        """
+        if self.group_size != 1:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    "robotwin group_size must be 1: the Runtime binds one session "
+                    "per lane, so rlinf's group replication has no meaning here",
+                    group_size=self.group_size,
+                )
+            )
+        if self.action_dim != ROBOTWIN_ACTION_DIM:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"robotwin is bimanual and requires action_dim="
+                    f"{ROBOTWIN_ACTION_DIM}",
+                    action_dim=self.action_dim,
+                )
+            )
+        if self.execute_horizon is not None and self.execute_horizon < 1:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    "robotwin execute_horizon must be >= 1 when set",
+                    execute_horizon=self.execute_horizon,
+                )
+            )
+        if not self.assets_path:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    "robotwin assets_path must point at the RoboTwin repository "
+                    "root (not its assets/ subdirectory)",
+                )
+            )
+
+    def task_config(self) -> dict[str, Any]:
+        """Build RoboTwin's ``task_config`` block.
+
+        Returns:
+            A plain dict suitable for ``VectorEnv(task_config=...)``.
+        """
+        return {
+            "task_name": self.task_name,
+            "step_lim": int(self.step_lim),
+            "planner_backend": self.planner_backend,
+            "render_freq": 0,
+            "episode_num": 100,
+            "use_seed": False,
+            "save_freq": 15,
+            "embodiment": list(self.embodiment),
+            "language_num": 100,
+            "domain_randomization": dict(self.domain_randomization),
+            "camera": {
+                "head_camera_type": self.head_camera_type,
+                "wrist_camera_type": self.wrist_camera_type,
+                "collect_head_camera": bool(self.collect_head_camera),
+                "collect_wrist_camera": bool(self.collect_wrist_camera),
+            },
+            "data_type": {
+                "rgb": True,
+                "third_view": False,
+                "depth": False,
+                "pointcloud": False,
+                "observer": False,
+                "endpose": False,
+                "qpos": True,
+                "mesh_segmentation": False,
+                "actor_segmentation": False,
+            },
+            "pcd_down_sample_num": 1024,
+            "pcd_crop": True,
+            "save_path": "./data",
+            "clear_cache_freq": 1,
+            # The Runtime owns episode artifacts; the family must not also write
+            # its own dataset next to them.
+            "collect_data": False,
+            "eval_video_log": bool(self.save_video),
+            **dict(self.extra_task_config),
+        }
+
+    def to_rlinf_cfg(self) -> Any:
+        """Project into the config object ``RoboTwinEnv(cfg=...)`` expects.
+
+        Returns:
+            A ``DictConfig`` when omegaconf is importable, otherwise a plain
+            ``SimpleNamespace``-backed equivalent. The vendored env reads the
+            config through ``getattr``/``.get``, so both work; falling back
+            keeps the core constructible in a test environment without
+            omegaconf.
+        """
+        payload = {
+            "env_type": ROBOTWIN_ENV_FAMILY,
+            "seed": int(self.seed),
+            "auto_reset": bool(self.auto_reset),
+            "ignore_terminations": bool(self.ignore_terminations),
+            "use_rel_reward": bool(self.use_rel_reward),
+            "use_custom_reward": bool(self.use_custom_reward),
+            "use_fixed_reset_state_ids": bool(self.use_fixed_reset_state_ids),
+            "is_eval": bool(self.is_eval),
+            "group_size": int(self.group_size),
+            "reward_coef": float(self.reward_coef),
+            "max_episode_steps": int(self.max_episode_steps),
+            "center_crop": bool(self.center_crop),
+            "assets_path": self.assets_path,
+            "seeds_path": self.seeds_path,
+            "video_cfg": {
+                "save_video": bool(self.save_video),
+                "info_on_video": bool(self.save_video),
+                "video_base_dir": self.video_base_dir,
+            },
+            "task_config": self.task_config(),
+        }
+        try:
+            from omegaconf import OmegaConf
+        except ImportError:
+            return _PlainConfig(payload)
+        return OmegaConf.create(payload)
+
+
+class _PlainConfig:
+    """Minimal attribute/``get`` view over a nested dict.
+
+    Stands in for an OmegaConf ``DictConfig`` when omegaconf is absent, which is
+    the case in the minimal test environment. Only the access patterns the
+    vendored env actually uses are supported: attribute reads, ``.get(key,
+    default)``, and nested dicts behaving the same way.
+    """
+
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        """Wrap a mapping.
+
+        Args:
+            payload: The configuration mapping.
+        """
+        self._payload = dict(payload)
+
+    def __getattr__(self, name: str) -> Any:
+        """Read a key as an attribute.
+
+        Args:
+            name: The key.
+
+        Returns:
+            The value, wrapped when it is itself a mapping.
+
+        Raises:
+            AttributeError: The key is absent.
+        """
+        payload = object.__getattribute__(self, "_payload")
+        if name not in payload:
+            raise AttributeError(name)
+        value = payload[name]
+        return _PlainConfig(value) if isinstance(value, Mapping) else value
+
+    def get(self, name: str, default: Any = None) -> Any:
+        """Read a key with a default.
+
+        Args:
+            name: The key.
+            default: Returned when the key is absent.
+
+        Returns:
+            The value, wrapped when it is itself a mapping.
+        """
+        if name not in self._payload:
+            return default
+        value = self._payload[name]
+        return _PlainConfig(value) if isinstance(value, Mapping) else value
+
+    def to_container(self) -> dict[str, Any]:
+        """Return the underlying plain dict.
+
+        Returns:
+            The wrapped mapping.
+        """
+        return dict(self._payload)
+
+
+def _robotwin_env_class() -> type:
+    """Lazily fetch ``RoboTwinEnv``.
+
+    Not imported at module top level: the module needs ``gymnasium`` and, on
+    construction, the ``robotwin`` package, neither of which exists in the
+    minimal test environment. A top-level import would break collection of the
+    whole ``tests/runtime`` suite.
+
+    Returns:
+        The ``RoboTwinEnv`` class.
+    """
+    from zetta.envs.robotwin.environment import RoboTwinEnv
+
+    return RoboTwinEnv
+
+
+def _close_env(env: Any, *, teardown: bool) -> None:
+    """Release one family env.
+
+    Args:
+        env: The family env, or ``None``.
+        teardown: Whether to actually call the family's teardown. When false
+            this is a no-op and the SAPIEN subprocesses are left to be reaped
+            when the worker process exits -- see :meth:`RobotwinEnvCore.close`
+            for why that is the default.
+    """
+    if env is None or not teardown:
+        return
+    for method in ("offload", "close"):
+        closer = getattr(env, method, None)
+        if callable(closer):
+            try:
+                closer()
+                return
+            except BaseException:  # noqa: BLE001 - teardown must not mask the real error
+                continue
+
+
+class RobotwinEnvCore:
+    """The RoboTwin family's ``EnvExecutionCore`` (blocking/synchronous)."""
+
+    def __init__(self) -> None:
+        """Initialize a not-yet-``build``-ed execution core."""
+        self.config = RobotwinEnvConfig()
+        self.env_spec: EnvSpecMsg | None = None
+        self.seed_offset = 0
+        self.closed = False
+        self.total_chunk_calls = 0
+        self.total_env_steps = 0
+        self.total_discarded_actions = 0
+        self._core_form = PER_SLOT_FORM
+        self._lanes: list[LaneState] = []
+        self._envs: list[Any] = []
+
+    @property
+    def behavior(self) -> EnvFamilyBehavior:
+        """The robotwin family's declaration across the six divergence axes.
+
+        Returns:
+            The family declaration.
+        """
+        return behavior_for(ROBOTWIN_ENV_FAMILY)
+
+    @property
+    def core_form(self) -> str:
+        """This core instance's form.
+
+        Returns:
+            Always ``per_slot`` for this family.
+        """
+        return self._core_form
+
+    # ------------------------------------------------- Construction and release
+
+    def build(
+        self,
+        env_spec: EnvSpecMsg,
+        *,
+        num_envs: int,
+        seed_offset: int = 0,
+        total_num_processes: int = 1,
+    ) -> None:
+        """Construct one ``RoboTwinEnv`` per slot.
+
+        Args:
+            env_spec: The environment spec.
+            num_envs: Number of slots in the pool.
+            seed_offset: Seed offset for this rank.
+            total_num_processes: Total processes sharing the seed pool.
+
+        Raises:
+            RuntimeApiError: ``num_envs`` is invalid or exceeds the family's
+                declared ceiling (``INVALID_ARGUMENT``), or the family failed
+                to construct (``ENV_FAILURE``).
+        """
+        if num_envs < 1:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT, f"num_envs must be >= 1, got {num_envs}"
+                )
+            )
+        behavior = self.behavior
+        if behavior.max_pool_size is not None and num_envs > behavior.max_pool_size:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"robotwin pools are capped at {behavior.max_pool_size} slots: "
+                    "SAPIEN raises 'cannot create buffer' once the total number of "
+                    "rendered cameras exhausts device memory, and the ceiling is a "
+                    "whole-device budget rather than a per-rank one",
+                    num_envs=num_envs,
+                    max_pool_size=behavior.max_pool_size,
+                )
+            )
+        config = RobotwinEnvConfig.from_mapping(env_spec.env_config)
+        core_form = requested_core_form(env_spec, behavior)
+        env_class = _robotwin_env_class()
+        lanes: list[LaneState] = []
+        envs: list[Any] = []
+        try:
+            for slot_index in range(num_envs):
+                envs.append(
+                    self._make_env(
+                        env_class,
+                        config,
+                        seed_offset=seed_offset * num_envs + slot_index,
+                        total_num_processes=max(1, total_num_processes) * num_envs,
+                    )
+                )
+                lanes.append(LaneState(env_index=slot_index, lane_index=0))
+        except RuntimeApiError:
+            for env in envs:
+                _close_env(env, teardown=config.teardown_on_close)
+            raise
+        except BaseException as exc:
+            for env in envs:
+                _close_env(env, teardown=config.teardown_on_close)
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.ENV_FAILURE,
+                    "failed to build the robotwin env pool: "
+                    f"{type(exc).__name__}: {exc}",
+                    task_name=config.task_name,
+                    num_envs=num_envs,
+                    core_form=core_form,
+                )
+            ) from exc
+        self.config = config
+        self.env_spec = env_spec
+        self.seed_offset = seed_offset
+        self._core_form = core_form
+        self._lanes = lanes
+        self._envs = envs
+        self.closed = False
+
+    def _make_env(
+        self,
+        env_class: type,
+        config: RobotwinEnvConfig,
+        *,
+        seed_offset: int,
+        total_num_processes: int,
+    ) -> Any:
+        """Construct one single-lane ``RoboTwinEnv`` and clear ``is_start``.
+
+        ``is_start`` follows the same reasoning as libero and maniskill: the
+        family takes a "decide the reset state myself" branch on the very first
+        reset, while the Runtime always supplies explicit parameters, so the
+        first episode must follow the same path as every later one.
+
+        Args:
+            env_class: ``RoboTwinEnv``.
+            config: The family config.
+            seed_offset: Seed offset for this slot.
+            total_num_processes: Total processes for the seed partition.
+
+        Returns:
+            The constructed env.
+        """
+        env = env_class(
+            cfg=config.to_rlinf_cfg(),
+            num_envs=1,
+            seed_offset=seed_offset,
+            total_num_processes=total_num_processes,
+            worker_info=None,
+        )
+        env.is_start = False
+        return env
+
+    def close(self) -> None:
+        """Drop the pool's references without tearing SAPIEN down.
+
+        ``RoboTwinEnv.offload()`` -> ``VectorEnv.close()`` **segfaults** during
+        SAPIEN/subprocess teardown (reproduced on every S3 run: the crash lands
+        after the last episode's result and before the summary line, see
+        ``plan/robotwin_s0_findings.md``). A segfault cannot be caught in
+        process, so calling it would take the whole EnvWorker down every time a
+        session pool is released -- turning an ordinary ``close_sessions`` into
+        a worker restart.
+
+        So the default is to release the references and let the SAPIEN
+        subprocesses be reaped when the worker process exits. That matches how
+        the Runtime actually uses this family: pools are pre-allocated per
+        ``EnvSpecMsg`` digest and do not grow, so a worker builds a small fixed
+        number of them over its lifetime rather than churning through pools.
+
+        The real teardown stays reachable through
+        ``env_config.teardown_on_close`` for a RoboTwin build where the crash is
+        fixed.
+        """
+        for env in self._envs:
+            _close_env(env, teardown=self.config.teardown_on_close)
+        self._lanes = []
+        self._envs = []
+        self.closed = True
+
+    # ------------------------------------------------------------- Operations
+
+    def reset(self, slots: Sequence[int], reset_spec: ResetSpec) -> list[Observation]:
+        """Reset the given slots.
+
+        The family signature is ``reset(env_idx, env_seeds)``. Each slot owns a
+        single-lane env, so ``env_idx`` stays ``None`` (meaning "all lanes of
+        this env") and the scene is selected purely by ``env_seeds``.
+
+        Seed precedence is ``reset_state_id`` > ``seed`` > the family's own
+        schedule. RoboTwin's seed *is* its scene identity, so an explicit
+        ``reset_state_id`` must win over the curated success-seed rotation --
+        that is what makes a paired same-seed gate reproducible.
+
+        Args:
+            slots: The slot indices.
+            reset_spec: Episode initialization parameters.
+
+        Returns:
+            The initial observations, in the same order as ``slots``.
+        """
+        observations: list[Observation] = []
+        for slot_index in slots:
+            lane = self._require_lane(slot_index)
+            env = self._envs[lane.env_index]
+            env_seeds = self._resolve_seeds(reset_spec)
+            payload, _info = env.reset(env_idx=None, env_seeds=env_seeds)
+            lane.begin_episode()
+            lane.instruction = self._instruction(payload, lane, reset_spec)
+            lane.extras = {
+                "task_name": self.config.task_name,
+                "reset_state_id": (int(env_seeds[0]) if env_seeds is not None else -1),
+            }
+            observations.append(self._observation(slot_index, payload))
+        return observations
+
+    def _resolve_seeds(self, reset_spec: ResetSpec) -> list[int] | None:
+        """Pick the seed list for one single-lane reset.
+
+        Args:
+            reset_spec: Episode initialization parameters.
+
+        Returns:
+            A one-element seed list, or ``None`` to let the family use its own
+            schedule.
+        """
+        if reset_spec.reset_state_id is not None:
+            return [int(reset_spec.reset_state_id)]
+        if reset_spec.seed is not None:
+            return [int(reset_spec.seed)]
+        return None
+
+    def observe(self, slots: Sequence[int]) -> list[Observation]:
+        """Read the cached observation without changing environment state.
+
+        Args:
+            slots: The slot indices.
+
+        Returns:
+            Observations in the same order as ``slots``.
+
+        Raises:
+            RuntimeApiError: The slot has not been reset yet
+                (``SESSION_NOT_READY``).
+        """
+        observations: list[Observation] = []
+        for slot_index in slots:
+            lane = self._require_lane(slot_index)
+            if lane.last_observation is None:
+                raise RuntimeApiError(
+                    make_error(
+                        ErrorCode.SESSION_NOT_READY,
+                        f"robotwin slot {slot_index} has not been reset yet",
+                        slot_index=slot_index,
+                    )
+                )
+            observations.append(lane.last_observation)
+        return observations
+
+    def lane_status(self, slots: Sequence[int]) -> list[LaneStatus]:
+        """Read lane lifecycle snapshots.
+
+        Args:
+            slots: The slot indices.
+
+        Returns:
+            Snapshots in the same order as ``slots``.
+        """
+        return lane_statuses(self._lanes, slots)
+
+    def chunk_step(
+        self, slots: Sequence[int], chunk_actions: Sequence[np.ndarray]
+    ) -> list[ChunkOutcome]:
+        """Execute an action chunk on the given slots.
+
+        Args:
+            slots: The slot indices.
+            chunk_actions: Each slot's ``[chunk, 14]`` actions.
+
+        Returns:
+            Normalized results in the same order as ``slots``.
+
+        Raises:
+            RuntimeApiError: The number of slots does not match the number of
+                action blocks (``INVALID_ARGUMENT``).
+        """
+        if len(slots) != len(chunk_actions):
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"chunk_step got {len(slots)} slots but "
+                    f"{len(chunk_actions)} action blocks",
+                )
+            )
+        return [
+            self._chunk_step_one(slot_index, actions)
+            for slot_index, actions in zip(slots, chunk_actions, strict=True)
+        ]
+
+    def extension(
+        self, slot: int, namespace: str, method: str, args: dict[str, Any]
+    ) -> dict[str, Any]:
+        """RoboTwin declares no privileged extensions.
+
+        Args:
+            slot: The slot index.
+            namespace: Extension namespace.
+            method: Extension method name.
+            args: Method arguments.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            RuntimeApiError: Always ``UNSUPPORTED_EXTENSION`` -- the family's
+                ``extensions`` set is empty, so this is declaratively rejected
+                rather than crashed.
+        """
+        raise RuntimeApiError(
+            make_error(
+                ErrorCode.UNSUPPORTED_EXTENSION,
+                f"robotwin declares no extensions; got {namespace}.{method}",
+                namespace=namespace,
+                method=method,
+                slot=slot,
+            )
+        )
+
+    # ---------------------------------------------------------------- Helpers
+
+    def _require_lane(self, slot_index: int) -> LaneState:
+        """Look up a lane, rejecting out-of-range slots.
+
+        Args:
+            slot_index: The slot index.
+
+        Returns:
+            The lane state.
+
+        Raises:
+            RuntimeApiError: Index out of range (``INVALID_ARGUMENT``). Pools
+                are pre-allocated and do not grow.
+        """
+        if not 0 <= slot_index < len(self._lanes):
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"slot {slot_index} is outside the pool "
+                    f"(size {len(self._lanes)}); pools do not grow",
+                    slot_index=slot_index,
+                    pool_size=len(self._lanes),
+                )
+            )
+        return self._lanes[slot_index]
+
+    def _instruction(
+        self, payload: dict[str, Any], lane: LaneState, reset_spec: ResetSpec
+    ) -> str:
+        """Resolve the task instruction for a lane.
+
+        Args:
+            payload: The family's observation dict.
+            lane: Lane state.
+            reset_spec: Episode initialization parameters.
+
+        Returns:
+            The instruction string; falls back to the task name.
+        """
+        if reset_spec.instruction:
+            return str(reset_spec.instruction)
+        descriptions = payload.get("task_descriptions") or []
+        if lane.lane_index < len(descriptions):
+            return str(descriptions[lane.lane_index])
+        return self.config.task_name
+
+    def _split_wrist_views(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Unstack the family's wrist tensor onto the Runtime's obs fields (D1).
+
+        The family returns ``wrist_images`` shaped ``[num_envs, n, H, W, C]``
+        with ``n`` in ``{1, 2}``, plus ``wrist_image_names`` saying which wrist
+        each slice is. The Runtime instead has one ``wrist_image`` and a list of
+        ``extra_view_images``, so the left wrist becomes ``wrist_image`` and the
+        right wrist becomes ``extra_view_images[0]``.
+
+        The mapping is driven by the **names**, never by position: with a
+        right-wrist-only configuration slice 0 is the right wrist, and treating
+        it as the left one would hand the policy a mirrored view without any
+        error surfacing.
+
+        Args:
+            payload: The family's observation dict.
+
+        Returns:
+            A shallow copy with ``wrist_images`` / ``extra_view_images``
+            rewritten for ``observation_from_payload``.
+        """
+        rewritten = dict(payload)
+        wrist_raw = payload.get("wrist_images")
+        if wrist_raw is None:
+            rewritten["wrist_images"] = None
+            rewritten["extra_view_images"] = None
+            return rewritten
+
+        stack = to_numpy(wrist_raw)
+        names = list(payload.get("wrist_image_names") or [])
+        if not names:
+            # No self-description: fall back to the family's documented order
+            # (left first, then right) rather than guessing per-slice.
+            names = [LEFT_WRIST_KEY, RIGHT_WRIST_KEY][: stack.shape[1]]
+        index_by_name = {name: position for position, name in enumerate(names)}
+
+        left_position = index_by_name.get(LEFT_WRIST_KEY)
+        right_position = index_by_name.get(RIGHT_WRIST_KEY)
+        rewritten["wrist_images"] = (
+            stack[:, left_position] if left_position is not None else None
+        )
+        rewritten["extra_view_images"] = (
+            stack[:, right_position] if right_position is not None else None
+        )
+        return rewritten
+
+    def _observation(self, slot_index: int, payload: dict[str, Any]) -> Observation:
+        """Convert a family obs dict into an ``Observation`` and cache it.
+
+        ``observation_from_payload`` casts the state to float32, which RoboTwin
+        needs: its ``state`` arrives as float64 and ``obs_schema_digest``
+        compares dtypes across families.
+
+        Args:
+            slot_index: The slot index.
+            payload: The family's observation dict.
+
+        Returns:
+            An ``Observation``.
+        """
+        return observation_from_payload(
+            payload=self._split_wrist_views(payload),
+            lane=self._lanes[slot_index],
+            slot_index=slot_index,
+            env_family=ROBOTWIN_ENV_FAMILY,
+            core_form=self._core_form,
+        )
+
+    def _validate_block(self, slot_index: int, actions: np.ndarray) -> np.ndarray:
+        """Validate one slot's action shape and apply the execute horizon.
+
+        Args:
+            slot_index: The slot index.
+            actions: The actions.
+
+        Returns:
+            A ``[executed_chunk, 14]`` float32 array, truncated to
+            ``execute_horizon`` when one is configured.
+
+        Raises:
+            RuntimeApiError: The shape is wrong (``INVALID_ARGUMENT``).
+        """
+        block = np.asarray(actions, dtype=np.float32)
+        if block.ndim != 2 or block.shape[1] != self.config.action_dim:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    f"robotwin expects [chunk, {self.config.action_dim}] actions, got "
+                    f"shape {tuple(int(dim) for dim in block.shape)}",
+                    action_dim=self.config.action_dim,
+                    slot_index=slot_index,
+                )
+            )
+        if block.shape[0] < 1:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.INVALID_ARGUMENT,
+                    "robotwin chunk must contain at least one action",
+                    slot_index=slot_index,
+                )
+            )
+        horizon = self.config.execute_horizon
+        if horizon is not None and block.shape[0] > horizon:
+            self.total_discarded_actions += int(block.shape[0]) - horizon
+            block = block[:horizon]
+        return block
+
+    def _prepared_actions(self, batch: np.ndarray) -> np.ndarray:
+        """Run the batch through the family's ``prepare_actions``.
+
+        Args:
+            batch: Actions shaped ``[1, chunk, 14]``.
+
+        Returns:
+            A float32 numpy array in the family's expected layout.
+        """
+        from zetta.compat.actions import prepare_actions
+
+        prepared = prepare_actions(
+            batch,
+            env_type=ROBOTWIN_ENV_FAMILY,
+            model_type=self.config.action_model_type,
+            num_action_chunks=int(batch.shape[1]),
+            action_dim=int(batch.shape[2]),
+        )
+        return np.asarray(prepared, dtype=np.float32)
+
+    def _chunk_step_one(self, slot_index: int, actions: np.ndarray) -> ChunkOutcome:
+        """Submit one chunk to one lane and normalize the ``final_only`` result.
+
+        Unlike libero/maniskill this **does** call the family's own
+        ``chunk_step``: RoboTwin executes a submitted chunk inside a single
+        ``venv.step`` and cannot be driven step by step without changing what
+        the simulator does, so there is no per-step frame to collect and no
+        early stop to detect mid-chunk. ``executed_horizon`` is therefore the
+        submitted chunk length, and ``step_observations`` is ``None``.
+
+        Args:
+            slot_index: The slot index.
+            actions: Actions shaped ``[chunk, 14]``.
+
+        Returns:
+            The normalized result.
+
+        Raises:
+            RuntimeApiError: The slot has not been reset
+                (``SESSION_NOT_READY``) or the action shape is wrong
+                (``INVALID_ARGUMENT``).
+        """
+        lane = self._require_lane(slot_index)
+        lane.chunk_calls += 1
+        self.total_chunk_calls += 1
+        if not lane.started:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.SESSION_NOT_READY,
+                    f"robotwin slot {slot_index} has not been reset yet",
+                    slot_index=slot_index,
+                )
+            )
+        requested_horizon = int(np.asarray(actions).shape[0])
+        block = self._validate_block(slot_index, actions)
+        executed = int(block.shape[0])
+        env = self._envs[lane.env_index]
+
+        prepared = self._prepared_actions(block[None, ...])
+        obs_list, chunk_rewards, chunk_terms, chunk_truncs, infos_list = env.chunk_step(
+            prepared
+        )
+
+        rewards = self._lane_row(chunk_rewards, executed, float)
+        terminations = self._lane_row(chunk_terms, executed, bool)
+        truncations = self._lane_row(chunk_truncs, executed, bool)
+
+        lane.step_index += executed
+        lane.env_steps += executed
+        lane.terminated = lane.terminated or any(terminations)
+        lane.truncated = lane.truncated or any(truncations)
+        if lane.terminated or lane.truncated:
+            lane.frozen = True
+        self.total_env_steps += executed
+
+        payload = obs_list[-1] if obs_list else {}
+        observation = self._observation(slot_index, payload)
+
+        info = self._chunk_info(infos_list)
+        info["executed_horizon"] = executed
+        if executed != requested_horizon:
+            # The discard is the configured open-loop replan (D3), not a
+            # silent truncation: record it so a rollout record can show it.
+            info["discarded_actions"] = requested_horizon - executed
+
+        return normalize_chunk_outcome(
+            behavior=self.behavior,
+            final_observation=observation,
+            # final_only: RoboTwin never produces intermediate frames.
+            step_observations=None,
+            rewards=rewards,
+            terminations=terminations,
+            truncations=truncations,
+            requested_horizon=requested_horizon,
+            info=info,
+        )
+
+    @staticmethod
+    def _lane_row(matrix: Any, executed: int, caster: Any) -> list[Any]:
+        """Read lane 0's row out of a ``[1, chunk]`` family tensor.
+
+        The family returns chunk-shaped reward/flag matrices whose only
+        populated column is the last one, so the row maps directly onto the
+        per-step sequences ``normalize_chunk_outcome`` expects.
+
+        Args:
+            matrix: A ``[1, chunk]`` tensor or array.
+            executed: Expected row length.
+            caster: ``float`` or ``bool``.
+
+        Returns:
+            A list of length ``executed``.
+        """
+        array = to_numpy(matrix).reshape(1, -1)[0]
+        values = [caster(array[index]) for index in range(min(executed, array.size))]
+        while len(values) < executed:
+            values.append(caster(0))
+        return values
+
+    @staticmethod
+    def _chunk_info(infos_list: Sequence[Any]) -> dict[str, Any]:
+        """Extract a small, JSON-friendly info dict from the family's infos.
+
+        Only the success flag is carried across: the family's info also holds
+        whole observation tensors on the auto-reset path, which must never end
+        up inside a ``StepResult``.
+
+        Args:
+            infos_list: The family's per-chunk info list.
+
+        Returns:
+            A plain dict.
+        """
+        if not infos_list:
+            return {}
+        raw = infos_list[-1]
+        if not isinstance(raw, Mapping):
+            return {}
+        info: dict[str, Any] = {}
+        success = raw.get("success")
+        if success is not None:
+            array = to_numpy(success).reshape(-1)
+            if array.size:
+                info["success"] = bool(array[0])
+        return info
+
+
+def robotwin_env_capability() -> EnvFamilyCapability:
+    """Return the robotwin family's capability declaration.
+
+    Returns:
+        An ``EnvFamilyCapability``: **no** per-step observations
+        (``final_only``), needs an accelerator, no privileged extensions,
+        ``per_slot`` only, and ``reset_state_id`` **supported** -- RoboTwin's
+        ``env_seeds`` is exactly a reset-state selector, which the campaign
+        protocol's seed discipline relies on.
+    """
+    return capability_from_behavior(
+        behavior_for(ROBOTWIN_ENV_FAMILY),
+        supports_auto_reset=False,
+        supports_reset_state_id=True,
+    )
+
+
+class RobotwinEnvFamily:
+    """The RoboTwin family's ``EnvFamilyAdapter``."""
+
+    @property
+    def env_family(self) -> str:
+        """Family name.
+
+        Returns:
+            ``"robotwin"``.
+        """
+        return ROBOTWIN_ENV_FAMILY
+
+    @property
+    def capability(self) -> EnvFamilyCapability:
+        """The family's capability declaration.
+
+        Returns:
+            The capability table entry.
+        """
+        return robotwin_env_capability()
+
+    def create_core(self) -> RobotwinEnvCore:
+        """Create a not-yet-``build``-ed execution core.
+
+        Returns:
+            A ``RobotwinEnvCore`` instance.
+        """
+        return RobotwinEnvCore()
+
+
+def register_robotwin_env_family(*, replace: bool = True) -> RobotwinEnvFamily:
+    """Register the robotwin family into ``ENV_FAMILY_REGISTRY``.
+
+    Args:
+        replace: Whether to allow overwriting an existing registration under
+            the same name.
+
+    Returns:
+        The registered family adapter.
+    """
+    adapter = RobotwinEnvFamily()
+    register_env_family(adapter, replace=replace)
+    return adapter

--- a/rollout_runtime/config/presets/robotwin_pi05.yaml
+++ b/rollout_runtime/config/presets/robotwin_pi05.yaml
@@ -1,0 +1,187 @@
+# RoboTwin 2.0 + Pi0.5 preset（S2 交付物）。
+#
+# 对应 RLinf 的 evaluations/robotwin/robotwin_adjust_bottle_openpi_pi05_eval.yaml，
+# 参数已按本仓库的 Runtime 语义重排。三条与其他 preset 不同的地方：
+#
+#   1. env_worker.placement_strategy: packed —— RoboTwin 用 SAPIEN 渲染，缺 GPU 时
+#      直接报 "failed to find a rendering device"（env_registry.py 的
+#      needs_accelerator_override=True）。"node" 策略推断出的 has_accelerator=False
+#      会让 EnvWorkerRegistry.serves() 拒绝调度到这个 rank。
+#   2. max_sessions_per_rank / default_pool_size 受 SAPIEN 显存上限约束。24GB 卡上
+#      **全机** 32 个并发 env 会让 camera.take_picture() 抛
+#      "RuntimeError: cannot create buffer"，16 个稳定；而且这是整机预算不是每卡预算
+#      （把 32 个摊到 8 张卡同样失败，SAPIEN 不跟随 rank 的设备分配）。
+#      env_registry.py 的 max_pool_size=16 是硬上限，这里取更保守的值。
+#      实测记录见 plan/robotwin_s0_findings.md。
+#   3. env_config.execute_horizon: 25 —— 模型仍按 num_action_chunks=50 构建并输出
+#      50 步，但每次只提交前 25 步。RoboTwin 是唯一的 final_only 家族，一个 chunk
+#      只回一帧观测；按 50 走意味着 Critic 每 50 个仿真步才看到一帧，整个 episode
+#      只有 4 帧，因果归因无从谈起。
+#      这个值是实测出来的，不是推的（adjust_bottle，16 个 eval 种子）：
+#          horizon=50 → success_once 0.9375（与 RLinf 原生基线逐字一致），4 帧/episode
+#          horizon=25 → success_once 0.875，                              8 帧/episode
+#          horizon=16 → success_once 0.75,                               13 帧/episode
+#      注意：曾经的假设"更频繁的重规划通常还会提高成功率"是**错的**。Pi0.5 一次生成
+#      50 步连贯轨迹、SFT 数据也是整块执行的，中途打断并从运动状态重规划会落到训练分布
+#      之外。25 是在"证据密度翻倍"和"n=16 下与基线差异不显著"之间取的折中；
+#      要把这个选择做成结论需要更大样本（见 plan/robotwin_s0_findings.md §7）。
+#
+# assets_path 必须指向 RoboTwin **仓库根**，不是它的 assets/ 子目录 —— RoboTwin 内部
+# 再拼一层 assets/…，指错会得到 .../assets/assets/... 的 FileNotFoundError。
+
+env_family: robotwin
+env_config:
+  task_name: adjust_bottle
+  # 单元素 = 一台双臂机器人；三元素 = 两条手臂 + 间距，如 [piper, piper, 0.6]。
+  embodiment: ["aloha-agilex"]
+  # 占位符：替换成本机 RoboTwin 源码检出（分支 RLinf_support）的根目录。
+  assets_path: /path/to/RoboTwin
+  # 可选：RLinf 自带的策展 success-seed 表。留空则由家族自行采样种子。
+  # 注意 campaign 的 held-out 划分依赖显式 reset_state_id，二者不冲突：
+  # ResetSpec 里的显式种子始终优先于这张表。
+  seeds_path: null
+  # curobo 需要 CUDA 工具链现编，验证过的镜像里根本没有它；RLinf 自己的 RoboTwin
+  # 配置也一律选 mplib。
+  planner_backend: mplib
+  step_lim: 200
+  max_episode_steps: 200
+  # 相机原生 240x320；center_crop 会中心裁剪并 resize 到 224x224。
+  center_crop: false
+  collect_head_camera: true
+  # 三路视角（head + 左右腕）对应 pi05_aloha_robotwin 的 num_images_in_input: 3。
+  collect_wrist_camera: true
+  head_camera_type: D435
+  wrist_camera_type: D435
+  domain_randomization:
+    random_background: false
+    cluttered_table: false
+    clean_background_rate: 1
+    random_head_camera_dis: 0
+    random_table_height: 0
+    random_light: false
+    crazy_random_light_rate: 0
+  reward_coef: 1.0
+  use_custom_reward: true
+  use_rel_reward: false
+  # RLinf 公布的 eval 设 true（因此它报的 episode_len 恒为整个 horizon）。
+  # Runtime 侧默认关掉：终止信号是 Critic 的一手证据，不该被抹掉。
+  ignore_terminations: false
+  auto_reset: false
+  use_fixed_reset_state_ids: false
+  is_eval: true
+  group_size: 1
+  seed: 0
+  action_dim: 14
+  chunk_size: 25
+  execute_horizon: 25
+  action_model_type: openpi
+  save_video: false
+  # VectorEnv 的 SAPIEN 收尾会段错误（进程内捕获不了），所以 close() 默认只释放引用、
+  # 让子进程随 EnvWorker 进程退出而回收。详见 rlinf_robotwin.py 的 close() docstring。
+  teardown_on_close: false
+  core_form: per_slot
+
+cluster:
+  num_nodes: 1
+  component_placement: {}
+
+gateway:
+  gateway_epoch: 1
+  maintenance_interval_seconds: 1.0
+  default_lease_seconds: 1800.0
+  error_retention_seconds: 300.0
+  result_ttl_seconds: 300.0
+  heartbeat_timeout_seconds: 60.0
+  heartbeat_interval_seconds: 10.0
+  max_concurrency_per_rank: 4
+  metrics_namespace: rr
+
+transport:
+  kind: ray_channel
+  command_queue_size: 64
+  control_queue_size: 16
+  result_queue_size: 64
+  infer_request_queue_size: 16
+  infer_response_queue_size: 16
+  command_timeout_seconds: 600.0
+
+env_worker:
+  group_name: env
+  num_ranks: 1
+  # SAPIEN 渲染要占卡，不能用 node 策略（见文件头注释第 1 点）。
+  placement_strategy: packed
+  # 见文件头注释第 2 点：整机并发 env 上限，不是每卡上限。
+  max_sessions_per_rank: 4
+  default_pool_size: 4
+  seed_offset: 0
+
+rollout_worker:
+  group_name: rollout
+  num_ranks: 1
+  placement_strategy: packed
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  policy_id: pi05_aloha_robotwin
+  policy_family: openpi
+  policy_backend: zetta_openpi
+  device: cuda
+  dtype: bfloat16
+  max_concurrent_inferences: 4
+  # 字段与 RLinf 的 evaluations/robotwin/robotwin_adjust_bottle_openpi_pi05_eval.yaml
+  # 一一对应（那份配置实测 success_once=0.9375，见 plan/robotwin_s0_findings.md），
+  # 只是 openpi 那一块在本仓库叫 family_params。
+  policy_config:
+    model_type: openpi
+    # 占位符：替换成本机 checkpoint 路径。norm stats 随 checkpoint 一起发布，位于
+    # <model_path>/assets/physical-intelligence/robotwin/norm_stats.json —— 这正是
+    # dataconfig 里 repo_id="physical-intelligence/robotwin" 所指的本地命名空间，
+    # 由 openpi 的 load_norm_stats(checkpoint_dir, asset_id) 读取，不是在线拉取。
+    model_path: /path/to/RLinf-Pi05-RoboTwin-SFT-adjust_bottle
+    # 模型按 50 构建（RLinf 明确注明 num_action_chunks 就是 Pi0 的 action_horizon，
+    # 且不读 checkpoint 里的 config.json）；执行侧截断由 env_config.execute_horizon 控制。
+    num_action_chunks: 50
+    action_dim: 14
+    num_steps: 5
+    use_proprio: true
+    # 与 RLinf eval 保持一致。SFT 权重里没有 value head，加载走 strict=False，
+    # 多出来的参数在推理路径上不参与计算；这里不偏离那份已验证的配置。
+    add_value_head: true
+    model_version: pi05
+    # ALOHA 的 _decode_aloha 用 wrist_images[0]/[1] 取左右腕，且完全不读
+    # extra_view_image。Runtime 的 Observation.wrist_image 只能装一张图，所以
+    # 双腕在 env 侧拆成 wrist_image(左) + extra_view_images[0](右)，这里再拼回
+    # [B, 2, H, W, C]。两者是配对的，改一边不改另一边不会报错，只会把畸形的腕部
+    # 张量喂进视觉塔。
+    stack_wrist_views: true
+    family_params:
+      # 本仓库已注册的 TrainConfig（dataconfig/__init__.py），与 RLinf eval 同名。
+      config_name: pi05_aloha_robotwin
+      # 三路视角：head + 左腕 + 右腕，与 env_config.collect_wrist_camera 对应。
+      num_images_in_input: 3
+      noise_level: 0.3
+      train_expert_only: true
+      noise_method: flow_sde
+      value_after_vlm: false
+      value_vlm_mode: mean_token
+      detach_critic_input: true
+      use_dsrl: false
+  scheduler:
+    max_batch_size: 4
+    max_wait_ms: 20.0
+    max_queue_depth: 32
+    max_inflight_per_application: 8
+    max_inflight_per_session: 1
+    fixed_batch_size: null
+
+admission:
+  require_auth: false
+  tokens: {}
+  max_sessions_per_application: 8
+  max_inflight_operations_per_application: 16
+  max_inflight_operations_per_session: 2
+  max_total_inflight_operations: 32
+
+payload:
+  inline_threshold_bytes: 262144
+  request_limit_bytes: 8388608
+  image_codec: png

--- a/rollout_runtime/core/env_registry.py
+++ b/rollout_runtime/core/env_registry.py
@@ -14,10 +14,9 @@ The registry mechanism and Protocol live here; this module also holds the
 accelerator is needed, and which privileged extensions exist. Separating
 declaration from implementation means neither the Gateway nor the
 EnvWorker needs an ``if env_family == ...`` branch, and a family that is
-"declared but not implemented in this build" (currently only
-``robotwin``, whose package is absent from the validated runtime images)
-gets a clear ``UNSUPPORTED_ENV_SPEC`` + ``declared=True`` instead of a
-``KeyError``.
+declared but has no adapter in a given build gets a clear
+``UNSUPPORTED_ENV_SPEC`` + ``declared=True`` instead of a ``KeyError``.
+Every declared family currently ships an adapter.
 """
 
 from __future__ import annotations
@@ -43,6 +42,7 @@ __all__ = [
     "MANISKILL_ENV_FAMILY",
     "ROBOCASA_ENV_FAMILY",
     "ROBOCASA_EXTENSIONS",
+    "ROBOTWIN_ENV_FAMILY",
     "EnvFamilyAdapter",
     "behavior_for",
     "capability_from_behavior",
@@ -62,6 +62,10 @@ MANISKILL_ENV_FAMILY = "maniskill"
 
 ROBOCASA_ENV_FAMILY = "robocasa"
 """The robocasa family name (a second family, CPU subprocess)."""
+
+ROBOTWIN_ENV_FAMILY = "robotwin"
+"""The robotwin family name (RoboTwin 2.0, bimanual, the sole ``final_only``
+family)."""
 
 CORE_FORM_CONFIG_KEY = "core_form"
 """The key in ``env_config`` that selects the execution-core form. It
@@ -211,23 +215,36 @@ ENV_FAMILY_BEHAVIORS: dict[str, EnvFamilyBehavior] = {
         core_forms=frozenset({PER_SLOT_FORM}),
         obs_extraction="RoboCasaSession.observation (raw gym dict) -> Observation",
     ),
-    # robotwin remains "declared only, not implemented": the `robotwin`
-    # package is absent from every validated runtime image, and pulling
-    # it in would require an entire asset bundle. Keeping this
-    # declaration matters because
-    # (a) it is the **only** `final_only` family across all of rlinf
-    # (robotwin_env.py:322 submits the whole chunk and only returns 1
-    # obs), which is the counter-example fact for normalization; and
-    # (b) create_session therefore gets a clear "declared but not
-    # implemented in this build" instead of "unknown family".
-    "robotwin": EnvFamilyBehavior(
-        env_family="robotwin",
-        env_type="robotwin",
+    # robotwin is the **only** `final_only` family: RoboTwinEnv.chunk_step
+    # (robotwin_env.py:322 at rlinf ref 9ad44393) submits the whole chunk in a
+    # single `venv.step` and returns exactly one observation regardless of the
+    # chunk length. That is the counter-example `normalize_chunk_outcome` was
+    # built around, and it means `ChunkOutcome.per_step` is always None here.
+    ROBOTWIN_ENV_FAMILY: EnvFamilyBehavior(
+        env_family=ROBOTWIN_ENV_FAMILY,
+        env_type=ROBOTWIN_ENV_FAMILY,
         reset_signature="env_idx_env_seeds",
         chunk_obs_layout="final_only",
         action_layout="numpy_env_chunk_dim",
+        # `VectorEnv` is a plain multiprocessing pool -- not a batched-GPU
+        # tensor family like maniskill -- but SAPIEN will not initialise a
+        # renderer without a GPU (`failed to find a rendering device`), so it
+        # declares the accelerator requirement explicitly, exactly as robocasa
+        # does. Verified on hardware, 2026-09-02.
         device_kind="cpu_subproc",
-        obs_extraction="RoboTwinEnv._wrap_obs -> EnvOutput.prepare_observations",
+        needs_accelerator_override=True,
+        # per_slot only: VectorEnv already owns its own subprocess fan-out, so
+        # there is no second "several lanes in one process" form to expose.
+        core_forms=frozenset({PER_SLOT_FORM}),
+        # A whole-device budget, not a per-rank one: on 24 GB cards a total of
+        # 32 concurrent RoboTwin envs makes SAPIEN raise
+        # `RuntimeError: cannot create buffer` inside `camera.take_picture()`,
+        # while 16 is stable -- and splitting the same 32 across more ranks does
+        # not help, because SAPIEN does not follow the rank's device
+        # assignment. Measured on 8x RTX 4090; see
+        # `plan/robotwin_s0_findings.md`.
+        max_pool_size=16,
+        obs_extraction="RoboTwinEnv._extract_obs_image -> Observation",
     ),
 }
 """The declaration table of real env families across the six divergence
@@ -412,9 +429,8 @@ def get_env_family(env_family: str) -> EnvFamilyAdapter:
         declared = env_family in ENV_FAMILY_BEHAVIORS
         message = (
             f"env family {env_family!r} is declared in ENV_FAMILY_BEHAVIORS but no "
-            "adapter is registered in this build (this build ships libero / "
-            "maniskill / robocasa; robotwin stays declaration-only because the "
-            "`robotwin` package is absent from the validated runtime images)"
+            "adapter is registered in this build; call "
+            "`backends.register_env_family_for` first"
             if declared
             else f"unknown env family: {env_family!r}"
         )

--- a/scripts/deployment/install_vla_env.sh
+++ b/scripts/deployment/install_vla_env.sh
@@ -515,3 +515,5 @@ fi
 echo
 echo "Known limitation: the libero-pro and robocasa tracks cannot be installed in the same venv state" \
      "because their robosuite versions conflict at the code level. See the Known Limitations section in VLA_ENV_SETUP.md."
+echo "RoboTwin is a third, separately isolated environment: it is SAPIEN-based rather than robosuite-based," \
+     "so this script does not build it. Use the upstream RLinf image instead; see docs/robotwin.md."

--- a/scripts/deployment/visualize_robotwin_episode.py
+++ b/scripts/deployment/visualize_robotwin_episode.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zetta Contributors
+"""Dump RoboTwin camera frames so an episode can actually be looked at.
+
+RoboTwin records nothing on its own: ``robotwin/envs/vector_env.py`` sets
+``args["eval_video_log"] = False`` unconditionally, overriding whatever the task
+config asks for, and RLinf's ``robotwin_env`` stores ``video_cfg`` without ever
+reading it. So the frames have to be captured on the way past.
+
+This script drives the **real** ``RobotwinEnvCore``, which means the frames it
+writes are the ones a policy actually saw, with the D1 camera mapping applied
+(head -> ``main_image``, left wrist -> ``wrist_image``, right wrist ->
+``extra_view_images[0]``). Images arrive already PNG-encoded inside the
+``Observation``, so capturing a frame is writing those bytes out -- no re-encode,
+nothing to drift.
+
+Two modes:
+
+``--scene-only``
+    Reset at a few seeds and dump the opening frame of each. Cheap: no
+    checkpoint, a few seconds. Answers "what does this task look like".
+
+default
+    Run one episode under the policy and dump every simulator step. The env is
+    built with ``execute_horizon=1`` so each submitted action yields an
+    observation, while the policy is still only re-run every ``--replan-every``
+    steps -- that is the preset's control behaviour at full frame rate, rather
+    than the 8-frame slideshow a chunk-granular capture would give.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+import numpy as np  # noqa: E402
+
+from rollout_runtime.api.ids import EpisodeId, RequestId, SessionId  # noqa: E402
+from rollout_runtime.api.internal import InferenceRequest  # noqa: E402
+from rollout_runtime.api.messages import (  # noqa: E402
+    EnvSpecMsg,
+    Observation,
+    ResetSpec,
+)
+from rollout_runtime.backends.rlinf_robotwin import RobotwinEnvCore  # noqa: E402
+
+CAMERAS = ("head", "left_wrist", "right_wrist")
+"""Output names for the three views, in the order the contract fixes them."""
+
+
+def _frames(observation: Observation) -> dict[str, bytes]:
+    """Pull the PNG bytes for each camera out of an observation.
+
+    Args:
+        observation: A chunk-final observation.
+
+    Returns:
+        Camera name -> PNG bytes, omitting views the config did not render.
+    """
+    out: dict[str, bytes] = {}
+    if observation.main_image is not None:
+        out["head"] = observation.main_image.data
+    if observation.wrist_image is not None:
+        out["left_wrist"] = observation.wrist_image.data
+    if observation.extra_view_images:
+        out["right_wrist"] = observation.extra_view_images[0].data
+    return out
+
+
+def _write(frames: dict[str, bytes], root: Path, index: int) -> None:
+    """Write one step's frames.
+
+    Args:
+        frames: Camera name -> PNG bytes.
+        root: Output directory.
+        index: Step index, used in the file name.
+    """
+    for name, data in frames.items():
+        target = root / name
+        target.mkdir(parents=True, exist_ok=True)
+        (target / f"{index:04d}.png").write_bytes(data)
+
+
+def _encode_videos(root: Path, fps: int) -> dict[str, str]:
+    """Assemble one video per camera, when imageio can.
+
+    Args:
+        root: Directory holding the per-camera PNG folders.
+        fps: Output frame rate.
+
+    Returns:
+        Camera name -> written file path. Empty when no encoder is available;
+        the PNGs are the deliverable either way, so a missing ffmpeg is a
+        downgrade rather than a failure.
+    """
+    try:
+        import imageio.v2 as iio
+    except ImportError:
+        print("[viz] imageio unavailable; PNG frames only", flush=True)
+        return {}
+    written: dict[str, str] = {}
+    for name in CAMERAS:
+        folder = root / name
+        paths = sorted(folder.glob("*.png"))
+        if not paths:
+            continue
+        images = [iio.imread(path) for path in paths]
+        for suffix, kwargs in ((".mp4", {"fps": fps}), (".gif", {"duration": 1 / fps})):
+            target = root / f"{name}{suffix}"
+            try:
+                iio.mimsave(target, images, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - encoder availability varies
+                print(f"[viz] {name}{suffix} failed: {type(exc).__name__}", flush=True)
+                continue
+            written[name] = str(target)
+            break
+    return written
+
+
+def _env_config(args: argparse.Namespace, *, execute_horizon: int) -> dict[str, Any]:
+    """Build the family config for a capture run.
+
+    Args:
+        args: Parsed CLI arguments.
+        execute_horizon: Actions submitted per ``chunk_step``.
+
+    Returns:
+        The ``env_config`` mapping.
+    """
+    return {
+        "task_name": args.task,
+        "assets_path": args.assets_path,
+        "embodiment": list(args.embodiment),
+        "planner_backend": args.planner_backend,
+        "max_episode_steps": int(args.max_steps),
+        "step_lim": int(args.max_steps),
+        "execute_horizon": execute_horizon,
+        "collect_head_camera": True,
+        "collect_wrist_camera": True,
+        "center_crop": bool(args.center_crop),
+    }
+
+
+def capture_scenes(args: argparse.Namespace) -> dict[str, Any]:
+    """Dump the opening frame of several seeds, without loading a policy.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        A summary dict.
+    """
+    core = RobotwinEnvCore()
+    core.build(
+        EnvSpecMsg(
+            env_family="robotwin", env_config=_env_config(args, execute_horizon=1)
+        ),
+        num_envs=1,
+    )
+    root = Path(args.output_dir)
+    captured: list[int] = []
+    try:
+        for index, seed in enumerate(args.seeds):
+            observation = core.reset([0], ResetSpec(reset_state_id=int(seed)))[0]
+            frames = _frames(observation)
+            _write(frames, root / f"seed-{seed}", 0)
+            captured.append(int(seed))
+            print(
+                f"[viz] seed={seed} views={sorted(frames)} "
+                f"instruction={observation.instruction!r}",
+                flush=True,
+            )
+    finally:
+        core.close()
+    return {"mode": "scene_only", "seeds": captured, "output_dir": str(root)}
+
+
+def capture_episode(args: argparse.Namespace) -> dict[str, Any]:
+    """Run one episode under the policy and dump every simulator step.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        A summary dict.
+
+    Raises:
+        RuntimeError: The policy returned an error for a step.
+    """
+    from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig, RlinfPolicyCore
+
+    core = RobotwinEnvCore()
+    # execute_horizon=1: one observation per submitted action, so the capture is
+    # per simulator step rather than per chunk. The policy is still only re-run
+    # every --replan-every steps, so the control behaviour matches the preset.
+    core.build(
+        EnvSpecMsg(
+            env_family="robotwin", env_config=_env_config(args, execute_horizon=1)
+        ),
+        num_envs=1,
+    )
+    policy = RlinfPolicyCore(
+        RlinfPolicyConfig.from_mapping(json.loads(Path(args.policy_config).read_text()))
+    )
+    policy.load()
+
+    root = Path(args.output_dir) / f"seed-{args.seeds[0]}"
+    observation = core.reset([0], ResetSpec(reset_state_id=int(args.seeds[0])))[0]
+    _write(_frames(observation), root, 0)
+
+    buffer: list[list[float]] = []
+    success = False
+    step_index = 0
+    try:
+        while step_index < int(args.max_steps):
+            if not buffer:
+                response = policy.infer_batch(
+                    [
+                        InferenceRequest(
+                            request_id=RequestId(f"viz-{step_index}"),
+                            session_id=SessionId("viz"),
+                            episode_id=EpisodeId(0),
+                            policy_id=args.policy_id,
+                            observation=observation,
+                            routing_token="viz",
+                            compat_key="viz",
+                        )
+                    ]
+                )[0]
+                if response.error is not None:
+                    raise RuntimeError(f"policy failed: {response.error}")
+                from rollout_runtime.core.payload import decode_array
+
+                chunk = np.asarray(decode_array(response.actions), dtype=np.float32)
+                buffer = [list(row) for row in chunk[: int(args.replan_every)]]
+
+            action = np.asarray([buffer.pop(0)], dtype=np.float32)
+            outcome = core.chunk_step([0], [action])[0]
+            step_index += 1
+            observation = outcome.observation
+            if observation is not None:
+                _write(_frames(observation), root, step_index)
+            if outcome.info.get("success"):
+                success = True
+            if outcome.terminated or outcome.truncated:
+                break
+            if step_index % 25 == 0:
+                print(f"[viz] step {step_index} success={success}", flush=True)
+    finally:
+        core.close()
+
+    videos = _encode_videos(root, fps=args.fps)
+    print(f"[viz] captured {step_index} steps, success={success}", flush=True)
+    return {
+        "mode": "episode",
+        "seed": int(args.seeds[0]),
+        "steps": step_index,
+        "success": success,
+        "output_dir": str(root),
+        "videos": videos,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    Returns:
+        The configured parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="Dump RoboTwin camera frames for one task"
+    )
+    parser.add_argument("--task", default="adjust_bottle")
+    parser.add_argument(
+        "--assets-path",
+        required=True,
+        help="RoboTwin repository root (not its assets/ subdirectory)",
+    )
+    parser.add_argument("--embodiment", nargs="+", default=["aloha-agilex"])
+    parser.add_argument(
+        "--planner-backend", default="mplib", choices=["mplib", "curobo"]
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--seeds", nargs="+", type=int, required=True, help="RoboTwin scene seeds"
+    )
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--replan-every", type=int, default=25)
+    parser.add_argument("--fps", type=int, default=20)
+    parser.add_argument("--center-crop", action="store_true")
+    parser.add_argument("--policy-id", default="pi05_aloha_robotwin")
+    parser.add_argument(
+        "--policy-config",
+        default=None,
+        help="JSON file of RlinfPolicyConfig fields; required unless --scene-only",
+    )
+    parser.add_argument(
+        "--scene-only",
+        action="store_true",
+        help="Only dump the opening frame of each seed; no checkpoint needed",
+    )
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint.
+
+    Returns:
+        ``0`` on success.
+    """
+    args = build_parser().parse_args()
+    if args.scene_only:
+        summary = capture_scenes(args)
+    else:
+        if not args.policy_config:
+            raise SystemExit("--policy-config is required unless --scene-only")
+        summary = capture_episode(args)
+    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evolution/preflight_codex_stage.sh
+++ b/scripts/evolution/preflight_codex_stage.sh
@@ -1,0 +1,526 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Zetta Contributors
+set -uo pipefail
+umask 077
+
+# Verify that the Codex stage runtime can actually run before a campaign spends
+# a rollout budget reaching Diagnose and failing there.
+#
+# The campaign stages have no non-Codex path: zetta/evolution/stages.py builds
+# `build_planner("codex", ...)` unconditionally, and `--role1-planner` only
+# selects the rollout-side Role1 inside run_rollout.py.  Everything below is
+# therefore a hard requirement for Diagnose and every stage after it.
+#
+# Checks run to completion and report together; the script does not stop at the
+# first failure, because the usual case is several unrelated gaps at once.
+
+usage() {
+  local status=${1:-64}
+  cat <<'EOF'
+usage: preflight_codex_stage.sh [OPTIONS]
+
+Options:
+  --python PATH            Interpreter that will run the campaign (default: python3)
+  --provider-env FILE      Shell file exporting the provider credentials.  Must be
+                           mode 0600.  Never commit it; it is sourced, not parsed.
+  --model ID               Model id the campaign will freeze (default: gpt-5.6-sol)
+  --reasoning-effort LEVEL low|medium|high|xhigh (default: high)
+  --output-root DIR        Where the live probe writes its report.  Must not exist.
+                           (default: a fresh mktemp -d)
+  --timeout-s N            Live-probe timeout in seconds (default: 600)
+  --skip-probe             Run the static checks only; spend no API tokens.
+  -h, --help               Show this message.
+
+Exit codes: 0 all checks passed, 2 at least one check failed.
+EOF
+  exit "$status"
+}
+
+python_bin=${ZETTA_PREFLIGHT_PYTHON:-python3}
+provider_file=${PROVIDER_ENV_FILE:-${ZETTA_PROVIDER_ENV_FILE:-}}
+model=gpt-5.6-sol
+reasoning_effort=high
+output_root=
+timeout_s=600
+skip_probe=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python) [[ $# -ge 2 ]] || usage; python_bin=$2; shift 2 ;;
+    --provider-env) [[ $# -ge 2 ]] || usage; provider_file=$2; shift 2 ;;
+    --model) [[ $# -ge 2 ]] || usage; model=$2; shift 2 ;;
+    --reasoning-effort) [[ $# -ge 2 ]] || usage; reasoning_effort=$2; shift 2 ;;
+    --output-root) [[ $# -ge 2 ]] || usage; output_root=$2; shift 2 ;;
+    --timeout-s) [[ $# -ge 2 ]] || usage; timeout_s=$2; shift 2 ;;
+    --skip-probe) skip_probe=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) usage ;;
+  esac
+done
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+
+failures=0
+warnings=0
+
+pass()  { printf '  [ ok ] %s\n' "$*"; }
+fail()  { printf '  [FAIL] %s\n' "$*"; failures=$((failures + 1)); }
+warn()  { printf '  [warn] %s\n' "$*"; warnings=$((warnings + 1)); }
+info()  { printf '         %s\n' "$*"; }
+section() { printf '\n== %s\n' "$*"; }
+die()   { printf 'preflight_codex_stage: %s\n' "$*" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# 0. Credentials file
+# ---------------------------------------------------------------------------
+# Sourced before anything else so every later check sees the same environment
+# the campaign will see.  Left empty on purpose: fill in one of the four routes
+# described in section 3 and point --provider-env at the file.
+
+section "0. provider credential file"
+if [[ -n "$provider_file" ]]; then
+  if [[ ! -f "$provider_file" ]]; then
+    fail "provider env file does not exist: $provider_file"
+  else
+    provider_file=$(realpath "$provider_file")
+    mode=$(stat -c '%a' "$provider_file" 2>/dev/null || stat -f '%Lp' "$provider_file" 2>/dev/null || true)
+    if [[ -n "$mode" ]] && (( (8#$mode & 077) != 0 )); then
+      fail "provider env file must not be group/world accessible (chmod 600): $provider_file"
+    else
+      set -a
+      # shellcheck disable=SC1090
+      source "$provider_file"
+      set +a
+      pass "sourced $provider_file (mode ${mode:-unknown})"
+    fi
+  fi
+else
+  info "no --provider-env given; using the ambient environment"
+fi
+
+loopback_no_proxy=127.0.0.1,localhost,::1
+export NO_PROXY="${loopback_no_proxy}${NO_PROXY:+,${NO_PROXY}}"
+export no_proxy="${loopback_no_proxy}${no_proxy:+,${no_proxy}}"
+
+# ---------------------------------------------------------------------------
+# 1. Interpreter and Python packages
+# ---------------------------------------------------------------------------
+
+section "1. interpreter and packages"
+
+if [[ "$python_bin" == */* ]]; then
+  [[ -x "$python_bin" ]] || die "Python is not executable: $python_bin"
+  resolved_python=$(cd "$(dirname "$python_bin")" && pwd)/$(basename "$python_bin")
+else
+  resolved_python=$(command -v "$python_bin") || die "Python is not available: $python_bin"
+fi
+# Deliberately not `realpath`: resolving a venv's bin/python to the base
+# interpreter silently drops the venv, which is exactly the defect that killed
+# a full rollout batch through prepare_*_campaign.py.
+pass "interpreter $resolved_python"
+info "$("$resolved_python" -V 2>&1)"
+
+export PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}"
+
+# openai_codex is the planner SDK; the rest are what the campaign driver and the
+# loopback MCP server import at stage time.
+missing_modules=$(
+  "$resolved_python" - <<'PY'
+import importlib.util
+
+required = [
+    "zetta",
+    "openai_codex",
+    "mcp",
+    "httpx",
+    "pydantic_ai",
+    "fastapi",
+    "uvicorn",
+    "starlette",
+]
+print(" ".join(n for n in required if importlib.util.find_spec(n) is None))
+PY
+)
+if [[ -z "$missing_modules" ]]; then
+  pass "all planner/driver modules import"
+else
+  fail "missing Python modules: $missing_modules"
+  if [[ "$missing_modules" == *openai_codex* ]]; then
+    info "openai-codex>=0.1.0b3 is a project dependency (pyproject.toml)."
+    info "scripts/evolution/bootstrap_stage_runtime.sh only *validates* this"
+    info "import, it does not install it -- the base interpreter must already"
+    info "have it, e.g. via 'pip install -e .' or a targeted:"
+    info "  $resolved_python -m pip install 'openai-codex>=0.1.0b3'"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The codex CLI binary
+# ---------------------------------------------------------------------------
+# The wheel is a thin SDK that spawns a separate ~120MB CLI binary.  Installing
+# the package and obtaining the binary are two independent failures, and
+# CODEX_BIN (zetta/planner/codex.py) is the supported way to supply a binary
+# fetched out of band when the host cannot download it.
+
+section "2. codex CLI binary"
+
+# Resolution order matches what the SDK does: an explicit CODEX_BIN wins,
+# otherwise openai-codex-cli-bin ships its own binary inside site-packages, and
+# a `codex` on PATH is only a last resort.
+codex_bin=${CODEX_BIN:-}
+codex_source=
+if [[ -n "$codex_bin" ]]; then
+  if [[ -x "$codex_bin" ]]; then
+    codex_source="CODEX_BIN"
+  else
+    fail "CODEX_BIN is set but not executable: $codex_bin"
+    codex_bin=
+  fi
+fi
+
+if [[ -z "$codex_bin" ]]; then
+  bundled=$(
+    "$resolved_python" - <<'CODEXBIN' 2>/dev/null
+import importlib.util
+import pathlib
+
+# The distribution is openai-codex-cli-bin; the module it installs is codex_cli_bin.
+spec = importlib.util.find_spec("codex_cli_bin")
+if spec is not None and spec.origin:
+    candidate = pathlib.Path(spec.origin).parent / "bin" / "codex"
+    if candidate.is_file():
+        print(candidate)
+CODEXBIN
+  )
+  if [[ -n "$bundled" && -x "$bundled" ]]; then
+    codex_bin=$bundled
+    codex_source="openai-codex-cli-bin"
+  fi
+fi
+
+if [[ -z "$codex_bin" ]]; then
+  if codex_bin=$(command -v codex 2>/dev/null); then
+    codex_source="PATH"
+  else
+    codex_bin=
+  fi
+fi
+
+if [[ -n "$codex_bin" ]]; then
+  pass "codex binary via ${codex_source}: $codex_bin"
+else
+  fail "no codex CLI binary available"
+  info "The wheel and the binary are separate packages: openai-codex depends on"
+  info "openai-codex-cli-bin, a ~115MB platform wheel.  When the host cannot"
+  info "download it, fetch it elsewhere and install from a local wheelhouse:"
+  info "  pip install --find-links=/path/to/wheels openai-codex==<version>"
+  info "Or point CODEX_BIN at a binary copied in out of band."
+fi
+
+if [[ -n "$codex_bin" ]]; then
+  if version=$("$codex_bin" --version 2>&1); then
+    pass "codex --version -> ${version//$'\n'/ }"
+  else
+    fail "codex binary is present but did not run: ${version//$'\n'/ }"
+    info "A binary built for another libc/arch fails exactly like this."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Credentials
+# ---------------------------------------------------------------------------
+# Four mutually exclusive routes, resolved in CodexPlanner._build_config with
+# precedence D > C > B > A.  Presence only is reported; no value is printed.
+
+section "3. credentials"
+
+route_a=0; route_b=0; route_c=0; route_d=0
+{ [[ -f "${HOME:-}/.codex/auth.json" ]] || [[ -f "${HOME:-}/.codex/config.toml" ]]; } && route_a=1
+[[ -n "${CODEX_BASE_URL:-}" && -n "${CODEX_API_KEY:-}" ]] && route_b=1
+[[ -n "${ZETTA_API_PROVIDERS:-}" ]] && route_c=1
+[[ -n "${ZETTA_API_PROVIDER_BROKER_URL:-}" && -n "${ZETTA_API_PROVIDER_BROKER_API_KEY:-}" ]] && route_d=1
+
+if { [[ -n "${ZETTA_API_PROVIDER_BROKER_URL:-}" ]] && [[ -z "${ZETTA_API_PROVIDER_BROKER_API_KEY:-}" ]]; } ||
+   { [[ -z "${ZETTA_API_PROVIDER_BROKER_URL:-}" ]] && [[ -n "${ZETTA_API_PROVIDER_BROKER_API_KEY:-}" ]]; }; then
+  fail "ZETTA_API_PROVIDER_BROKER_URL and ZETTA_API_PROVIDER_BROKER_API_KEY must be set together"
+  info "zetta/planner/provider_proxy.py raises when only one is present."
+fi
+if [[ -n "${CODEX_BASE_URL:-}" && -z "${CODEX_API_KEY:-}" ]]; then
+  warn "CODEX_BASE_URL is set but CODEX_API_KEY is empty"
+fi
+
+if (( route_a + route_b + route_c + route_d == 0 )); then
+  fail "no provider credentials are configured"
+  cat <<'EOF'
+         Configure exactly one route (precedence D > C > B > A):
+           A  ~/.codex/{config.toml,auth.json}      codex's own configuration
+           B  CODEX_BASE_URL + CODEX_API_KEY        direct gateway
+           C  ZETTA_API_PROVIDERS (JSON)            local failover pool
+           D  ZETTA_API_PROVIDER_BROKER_URL
+              + ZETTA_API_PROVIDER_BROKER_API_KEY   external broker
+EOF
+else
+  (( route_a )) && info "A present: codex native config under ~/.codex"
+  (( route_b )) && info "B present: CODEX_BASE_URL + CODEX_API_KEY"
+  (( route_c )) && info "C present: ZETTA_API_PROVIDERS"
+  (( route_d )) && info "D present: broker URL + broker key"
+  if   (( route_d )); then effective=D
+  elif (( route_c )); then effective=C
+  elif (( route_b )); then effective=B
+  else                     effective=A
+  fi
+  pass "route $effective will be used"
+  if (( route_a + route_b + route_c + route_d > 1 )); then
+    warn "more than one route is configured; the others are ignored"
+  fi
+fi
+
+# When codex supplies the provider itself, the planner adds no model_provider
+# override (only a set CODEX_BASE_URL triggers that), so config.toml decides
+# where the request goes and which environment variable holds the key.
+if [[ -f "${HOME:-}/.codex/config.toml" ]]; then
+  native_report=$(
+    "$resolved_python" - "${HOME}/.codex/config.toml" <<'NATIVE' 2>/dev/null
+import os
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+try:
+    import tomllib
+
+    data = tomllib.loads(text)
+    provider = data.get("model_provider")
+    block = (data.get("model_providers") or {}).get(provider or "", {})
+    env_key = block.get("env_key")
+    base_url = block.get("base_url")
+    wire_api = block.get("wire_api")
+    query = block.get("query_params") or {}
+except Exception:
+    provider = (re.search(r'^model_provider\s*=\s*"([^"]+)"', text, re.M) or [None, None])[1]
+    env_key = (re.search(r'^env_key\s*=\s*"([^"]+)"', text, re.M) or [None, None])[1]
+    base_url = (re.search(r'^base_url\s*=\s*"([^"]+)"', text, re.M) or [None, None])[1]
+    wire_api = (re.search(r'^wire_api\s*=\s*"([^"]+)"', text, re.M) or [None, None])[1]
+    query = {}
+
+if not provider:
+    print("NONE")
+else:
+    have = "set" if (env_key and os.environ.get(env_key)) else "UNSET"
+    print(
+        f"PROVIDER\t{provider}\t{base_url}\t{wire_api}\t{env_key}\t{have}"
+        f"\t{'api-version' in query}"
+    )
+NATIVE
+  )
+  if [[ "$native_report" == PROVIDER* ]]; then
+    IFS=$'\t' read -r _ np nurl nwire nkey nhave nver <<<"$native_report"
+    pass "codex config.toml provider '$np' -> $nurl (wire_api=$nwire)"
+    if [[ "$nhave" == set ]]; then
+      pass "its env_key $nkey is set in this environment"
+    else
+      fail "its env_key $nkey is NOT set -- codex will have no credential"
+      info "Export it, or put it in the file passed to --provider-env."
+    fi
+    if [[ "$nwire" != responses ]]; then
+      warn "wire_api is '$nwire'; the stage planner expects a Responses endpoint"
+    fi
+    if [[ "$np" == azure* || "$nurl" == *azure* ]] && [[ "$nver" != True ]]; then
+      warn "an Azure provider usually needs query_params = { \"api-version\" = ... }"
+    fi
+    if [[ -n "${CODEX_BASE_URL:-}" ]]; then
+      warn "CODEX_BASE_URL is set, so this config.toml provider is overridden"
+      info "The override appends /v1 and carries no query_params; on Azure that breaks."
+    fi
+  fi
+fi
+
+# Validate ZETTA_API_PROVIDERS with the repo's own loader rather than a
+# re-implementation, so this agrees with what the planner will accept.
+if (( route_c )); then
+  pool_report=$(
+    "$resolved_python" - <<'PY'
+import sys
+
+try:
+    from zetta.planner.provider_pool import load_provider_pool_config
+except Exception as exc:  # pragma: no cover - import guard
+    print(f"ERR could not import the provider pool loader ({exc}); fix section 1 first")
+    sys.exit(0)
+
+try:
+    config = load_provider_pool_config(default_model="openai-responses:preflight")
+except Exception as exc:
+    # The message names the offending route but never echoes a key.
+    print(f"ERR {type(exc).__name__}: {exc}")
+    sys.exit(0)
+
+if config is None:
+    print("ERR ZETTA_API_PROVIDERS parsed to no configuration")
+    sys.exit(0)
+
+routes = getattr(config, "routes", ())
+print(f"OK {len(routes)} route(s): " + ", ".join(str(r.route_id) for r in routes))
+PY
+  )
+  if [[ "$pool_report" == OK* ]]; then
+    pass "ZETTA_API_PROVIDERS ${pool_report#OK }"
+  else
+    fail "ZETTA_API_PROVIDERS is invalid -- ${pool_report#ERR }"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Gateway wire API
+# ---------------------------------------------------------------------------
+# Once any base_url is in play, _codex_mcp_config_overrides pins
+# wire_api = "responses".  A gateway that only implements /v1/chat/completions
+# answers 404 on /responses and the stage dies mid-campaign.  Probed
+# unauthenticated on purpose: no key leaves this script.
+
+section "4. gateway wire API (responses)"
+
+gateway_url=${ZETTA_API_PROVIDER_BROKER_URL:-${CODEX_BASE_URL:-}}
+if [[ -z "$gateway_url" ]]; then
+  info "no explicit base_url; codex will use its own default endpoint"
+elif ! command -v curl >/dev/null 2>&1; then
+  warn "curl is unavailable; cannot probe ${gateway_url%/}/responses"
+else
+  probe_url="${gateway_url%/}/responses"
+  code=$(curl -s -o /dev/null -w '%{http_code}' -m 15 -X POST \
+           -H 'content-type: application/json' -d '{}' "$probe_url" 2>/dev/null) || code=
+  [[ "$code" =~ ^[0-9]{3}$ ]] || code=000
+  case "$code" in
+    000) warn "could not reach $probe_url (network, proxy, or TLS)" ;;
+    404) fail "$probe_url returned 404 -- gateway does not implement the Responses API"
+         info "wire_api is pinned to \"responses\"; a chat-completions-only"
+         info "gateway cannot serve the stage planner." ;;
+    401|403) pass "$probe_url returned $code (route exists, auth required)" ;;
+    400|422) pass "$probe_url returned $code (route exists, rejected the empty body)" ;;
+    *)   warn "$probe_url returned $code; interpret manually" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Loopback MCP transport
+# ---------------------------------------------------------------------------
+# Codex reaches back into this process over an HTTP MCP server bound to
+# 127.0.0.1 on a free port.  A proxy that swallows loopback, or a driver split
+# across the container boundary, breaks that leg while the outbound leg looks
+# healthy.
+
+section "5. loopback MCP transport"
+
+loopback_report=$(
+  "$resolved_python" - <<'PY'
+import http.server
+import socket
+import threading
+import urllib.request
+
+class Quiet(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = b"preflight"
+        self.send_response(200)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        return
+
+try:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+except OSError as exc:
+    print(f"ERR cannot bind a loopback port: {exc}")
+    raise SystemExit(0)
+
+server = http.server.HTTPServer(("127.0.0.1", port), Quiet)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+try:
+    # getproxies() honours http_proxy/no_proxy exactly as the real client does.
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5) as response:
+        payload = response.read()
+    print("OK" if payload == b"preflight" else "ERR unexpected loopback payload")
+except Exception as exc:
+    print(f"ERR loopback round trip failed: {type(exc).__name__}: {exc}")
+finally:
+    server.shutdown()
+PY
+)
+if [[ "$loopback_report" == OK ]]; then
+  pass "bound 127.0.0.1 on a free port and round-tripped a request"
+else
+  fail "${loopback_report#ERR }"
+  info "Check http_proxy/https_proxy: NO_PROXY must exempt 127.0.0.1."
+  info "The campaign driver and codex must share one network namespace --"
+  info "a driver outside the container cannot serve the in-container MCP port."
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Sandbox and working directory
+# ---------------------------------------------------------------------------
+
+section "6. sandbox and cwd"
+
+sandbox=${ZETTA_CODEX_SANDBOX:-full-access}
+sandbox_lc=$(printf '%s' "$sandbox" | tr '[:upper:]' '[:lower:]')
+case "$sandbox_lc" in
+  read-only|readonly|workspace-write|full-access|full)
+    pass "ZETTA_CODEX_SANDBOX=$sandbox" ;;
+  *)
+    fail "ZETTA_CODEX_SANDBOX must be read-only, workspace-write, or full-access; got '$sandbox'" ;;
+esac
+info "codex runs with cwd=$repo_root"
+if [[ "$sandbox_lc" == "full-access" || "$sandbox_lc" == "full" ]]; then
+  info "full-access is the historical default and permits writes under that cwd"
+fi
+
+case "$reasoning_effort" in
+  low|medium|high|xhigh) pass "reasoning effort $reasoning_effort" ;;
+  *) fail "--reasoning-effort must be low|medium|high|xhigh; got '$reasoning_effort'" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 7. Live single-turn probe
+# ---------------------------------------------------------------------------
+# One tool-free nonce turn.  Cheaper than discovering the same faults after a
+# campaign has spent its rollout budget getting to Diagnose.
+
+section "7. live probe"
+
+if (( skip_probe )); then
+  info "skipped (--skip-probe); no API tokens spent"
+elif (( failures > 0 )); then
+  info "skipped: fix the failures above first so the probe is meaningful"
+else
+  if [[ -z "$output_root" ]]; then
+    output_root=$(mktemp -d)/probe
+  fi
+  info "report -> $output_root/report.json"
+  if "$resolved_python" "$script_dir/probe_codex_stage_runtime.py" \
+      --output-root "$output_root" \
+      --model "$model" \
+      --reasoning-effort "$reasoning_effort" \
+      --timeout-s "$timeout_s"; then
+    pass "probe passed for model $model"
+  else
+    fail "probe failed; see $output_root/failure_summary.json"
+    info "It checks planner_error_absent, nonce_returned,"
+    info "persistent_thread_id_present, raw_stream_parse_complete and"
+    info "terminal_event_present -- the five things that break here."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+
+printf '\n== summary\n'
+if (( failures == 0 )); then
+  printf '  %d failure(s), %d warning(s) -- the Codex stage runtime is ready.\n' "$failures" "$warnings"
+  exit 0
+fi
+printf '  %d failure(s), %d warning(s) -- Diagnose and every later stage will not run.\n' "$failures" "$warnings"
+exit 2

--- a/scripts/evolution/prepare_robotwin_campaign.py
+++ b/scripts/evolution/prepare_robotwin_campaign.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zetta Contributors
+"""Create one immutable, secret-free RoboTwin evolution preregistration.
+
+The one place this differs materially from the LIBERO and RoboCasa preparers is
+the **seed population**, and the difference is forced.
+
+RoboTwin ships a curated per-task list of seeds on which the task is known to be
+solvable (``rlinf/envs/robotwin/seeds/eval_seeds.json``), and the environment
+selects its scene from that seed outright. Drawing a campaign's seeds from
+``range(population_size)`` the way the other preparers do would produce mostly
+scenes the task cannot be completed in at all, and a held-out gate whose success
+rate is structurally near zero is not a gate -- it is noise.
+
+So the population is the task's ``success_seeds``, the held-out block is its
+first ``--heldout-count`` entries, and the **provenance of both is written into
+the manifest and the preregistration**. The protocol's shape is unchanged --
+a fixed, disjoint, pre-committed held-out block frozen before any development
+rollout -- but the values are no longer the literal ``1..20``, and a reader must
+be able to see why without reading this file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from robots.robotwin.critic_runtime import describe_dwell_semantics  # noqa: E402
+from robots.robotwin.role1_actor import ROLE1_SYSTEM_CONTRACT  # noqa: E402
+from robots.robotwin.tool_bindings import binding_for_task  # noqa: E402
+from robots.robotwin.tool_catalog import (  # noqa: E402
+    DEFAULT_ROBOTWIN_TOOL_CATALOG,
+)
+from zetta.evolution.jsonio import (  # noqa: E402
+    atomic_write_json,
+    canonical_sha256,
+    file_sha256,
+    read_json,
+)
+from zetta.evolution.models import (  # noqa: E402
+    CampaignManifest,
+    CandidateBundle,
+    SafetyLayerConfig,
+)
+from zetta.evolution.schedule import preregister_seed_schedule  # noqa: E402
+from zetta.evolution.stages import (  # noqa: E402
+    CLUSTER_SYSTEM_PROMPT,
+    DIAGNOSIS_SYSTEM_PROMPT,
+    PROPOSAL_SYSTEM_PROMPT,
+)
+
+ENVIRONMENT = "robotwin"
+"""The manifest's environment label."""
+
+
+def load_success_seeds(seeds_path: Path, task: str) -> tuple[int, ...]:
+    """Read the curated solvable seeds for one RoboTwin task.
+
+    Args:
+        seeds_path: The RLinf ``eval_seeds.json`` (or a file of the same shape).
+        task: The RoboTwin task name.
+
+    Returns:
+        The task's success seeds, de-duplicated, in file order.
+
+    Raises:
+        ValueError: The file has no entry for the task, or the entry carries no
+            usable seeds.
+    """
+    payload = json.loads(seeds_path.read_text(encoding="utf-8"))
+    entry = payload.get(task)
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"{seeds_path} has no entry for RoboTwin task {task!r}; "
+            f"known tasks: {sorted(payload)[:8]}..."
+        )
+    seeds = entry.get("success_seeds")
+    if not isinstance(seeds, list) or not seeds:
+        raise ValueError(f"{seeds_path} lists no success_seeds for task {task!r}")
+    return tuple(dict.fromkeys(int(value) for value in seeds))
+
+
+def _rollout_command(args: argparse.Namespace) -> list[str]:
+    """Build the frozen per-episode rollout command.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The command, with the queue's substitution placeholders left in place.
+    """
+    script = (
+        Path(args.repository_root).resolve() / "robots" / "robotwin" / "run_rollout.py"
+    )
+    command = [
+        # `absolute()`, never `resolve()`: a venv's `bin/python` is a symlink to
+        # the base interpreter, and a venv is only active when it is invoked
+        # through its own path -- `sys.prefix` is derived from where
+        # `sys.executable` lives. Resolving the symlink freezes the base
+        # interpreter into the manifest, and every rollout then dies at
+        # `import numpy` with the venv's site-packages nowhere on the path.
+        str(Path(args.runtime_python).absolute()),
+        str(script),
+        # The runtime URL is passed directly rather than through an environment
+        # slot lease. The slot broker exists to arbitrate exclusive access to a
+        # per-slot env server, and its health contract is that server's
+        # single-writer protocol (`write_protocol.phase == "FREE"`), which the
+        # Rollout Runtime's serve does not speak. Under the Runtime the env
+        # slots are owned by the Gateway's own `EnvPool`, so leasing the shared
+        # serve endpoint at campaign level would double-book a resource the
+        # Gateway already arbitrates. Concurrency stays bounded by the
+        # manifest's logical slots and the preset's `default_pool_size`.
+        "--runtime-url",
+        args.runtime_url,
+        "--policy-id",
+        args.policy_id,
+        "--task",
+        "{task}",
+        "--assets-path",
+        args.assets_path,
+        "--embodiment",
+        *args.embodiment,
+        "--planner-backend",
+        args.planner_backend,
+        "--seed",
+        "{seed}",
+        "--policy-rng",
+        "{policy_rng}",
+        "--logical-id",
+        "{logical_id}",
+        "--attempt-index",
+        "{attempt_index}",
+        "--generation",
+        "{generation}",
+        # A paired gate rejects a command that cannot consume the frozen bundle
+        # (gate_runner._command_template); Gen0 is substituted with "none".
+        "--bundle",
+        "{bundle_file}",
+        "--bundle-sha256",
+        "{bundle_sha256}",
+        "--output-dir",
+        "{output_dir}",
+        "--result-file",
+        "{result_file}",
+        "--env-max-steps",
+        str(args.env_max_steps),
+        "--execute-horizon",
+        str(args.execute_horizon),
+        "--env-pool-size",
+        str(args.env_pool_size),
+        # Stage 1 refuses a diagnosis carrying fewer than three visual evidence
+        # items, and those come from per-camera video that only exists when the
+        # episode captures frames. A campaign whose episodes cannot be diagnosed
+        # is not a campaign, so this is not optional here.
+        "--capture-frames",
+        # Role1 is only reachable once a parent bundle supplies critic rules, so
+        # Gen0 never spends a provider call even with this configured.
+        "--role1-planner",
+        args.role1_planner,
+        "--role1-model",
+        args.role1_model,
+        "--reasoning-effort",
+        args.reasoning_effort,
+    ]
+    # No ``--runtime-token``: the frozen command goes into the manifest, and a
+    # bearer token must never be recorded in a campaign artifact. ``run_rollout``
+    # reads it from the inherited worker environment instead.
+    return command
+
+
+def _seed_provenance(
+    *, seeds_path: Path, task: str, population: tuple[int, ...], heldout_count: int
+) -> dict[str, Any]:
+    """Describe where the campaign's seeds came from.
+
+    Recorded in both the manifest and the preregistration: the held-out block is
+    no longer the literal ``1..20`` that the other environments use, and a
+    reviewer must be able to see the substitution without reading the preparer.
+
+    Args:
+        seeds_path: The curated seed file.
+        task: The RoboTwin task.
+        population: The seeds drawn from.
+        heldout_count: Size of the held-out block.
+
+    Returns:
+        A JSON-friendly provenance record.
+    """
+    return {
+        "schema_version": 1,
+        "population_kind": "robotwin_curated_success_seeds",
+        "source_file": str(seeds_path),
+        "source_file_sha256": file_sha256(seeds_path),
+        "task": task,
+        "population_size": len(population),
+        "heldout_selection": f"first {heldout_count} entries in file order",
+        "rationale": (
+            "RoboTwin selects its scene from the seed outright, and only the "
+            "curated success seeds are known to be solvable. Drawing from a "
+            "dense integer range would make the held-out gate structurally "
+            "near-zero and therefore not a gate. The protocol shape is "
+            "unchanged: a fixed, disjoint, pre-committed held-out block."
+        ),
+    }
+
+
+def prepare(args: argparse.Namespace) -> dict[str, Any]:
+    """Materialize a frozen manifest, prompt contract, catalog and schedule.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The preregistration payload.
+
+    Raises:
+        ValueError: The repository, runtime Python, or generation/parent
+            combination is invalid.
+    """
+    output = Path(args.output_root).resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    repository_root = Path(args.repository_root).resolve()
+    runtime_python = Path(args.runtime_python).resolve()
+    if not (repository_root / "robots" / "robotwin" / "run_rollout.py").is_file():
+        raise ValueError("repository root has no RoboTwin rollout entrypoint")
+    if not runtime_python.is_file():
+        raise ValueError("runtime Python does not exist")
+
+    prompt_contract = {
+        "agent_abstraction": {
+            "online_enabled": ["role1"],
+            "online_disabled": ["role0", "role2"],
+            "offline_campaign_control": ["cluster", "diagnoser", "evolver"],
+            "legacy_schema_labels": ["stage1", "stage2"],
+        },
+        "formal_agent": {
+            "model": args.agent_model,
+            "reasoning_effort": args.reasoning_effort,
+        },
+        "role1": ROLE1_SYSTEM_CONTRACT,
+        "cluster": CLUSTER_SYSTEM_PROMPT,
+        "stage1": DIAGNOSIS_SYSTEM_PROMPT,
+        "stage2": PROPOSAL_SYSTEM_PROMPT,
+    }
+    prompt_path = output / "prompt-contract.json"
+    atomic_write_json(prompt_path, prompt_contract, overwrite=False)
+
+    binding = binding_for_task(args.task)
+    catalog = {
+        **DEFAULT_ROBOTWIN_TOOL_CATALOG.public_dict(),
+        "task": args.task,
+        "binding_digest": binding.digest,
+        "task_binding": binding.public_dict(),
+        # The arm requirement is the part of this catalog that is expensive to
+        # get wrong, so it is surfaced rather than left implicit in the tools.
+        "arm_scoped_tools": list(binding.arm_scoped_tool_names),
+    }
+    catalog_path = output / "tool-catalog.json"
+    atomic_write_json(catalog_path, catalog, overwrite=False)
+
+    seeds_path = Path(args.seeds_path).resolve()
+    population = load_success_seeds(seeds_path, args.task)
+    heldout_seeds = population[: args.heldout_count]
+    if len(heldout_seeds) < args.heldout_count:
+        raise ValueError(
+            f"task {args.task!r} has only {len(population)} curated success "
+            f"seeds; need at least {args.heldout_count} for the held-out block"
+        )
+    rollout, heldout, policy_rng = preregister_seed_schedule(
+        master_seed=args.master_seed,
+        task=args.task,
+        rollout_count=args.rollout_count,
+        heldout_count=args.heldout_count,
+        population=population,
+        heldout_seeds=heldout_seeds,
+    )
+    seed_provenance = _seed_provenance(
+        seeds_path=seeds_path,
+        task=args.task,
+        population=population,
+        heldout_count=args.heldout_count,
+    )
+
+    parent_sha256 = None
+    bundle_files_by_sha: dict[str, str] = {}
+    if args.parent_bundle is not None:
+        parent_path = Path(args.parent_bundle).resolve()
+        parent = CandidateBundle.from_dict(read_json(parent_path))
+        parent_sha256 = parent.sha256
+        if parent.generation >= args.generation:
+            raise ValueError(
+                "parent bundle generation must precede campaign generation"
+            )
+        bundle_files_by_sha[parent_sha256] = str(parent_path)
+    elif args.generation != 0:
+        raise ValueError("nonzero generation requires --parent-bundle")
+
+    runtime_command = _rollout_command(args)
+    runtime = {
+        "evolution_policy": {
+            "same_seed_pass_rate": 0.5,
+            "max_candidate_rounds_per_cluster": 5,
+            "maximum_target_clusters": 2,
+        },
+        "rollout_command": runtime_command,
+        "same_seed_gate_rollout_command": runtime_command,
+        # Gen0 runs the Critic engine with an empty frozen rule set, so no
+        # online Role1 call is possible; pure-VLA throughput must not depend on
+        # provider admission.
+        "rollout_requires_api": parent_sha256 is not None,
+        "candidate_rollout_requires_api": True,
+        "reuse_rollout_parent_evidence": True,
+        "heldout_gate_kind": "heldout_20" if args.heldout_count == 20 else "heldout",
+        # See `_rollout_command`: the Gateway owns env-slot arbitration for this
+        # family, so the campaign does not also lease one.
+        "rollout_requires_environment_slot": False,
+        "bundle_files_by_sha": bundle_files_by_sha,
+        "agent_model": args.agent_model,
+        "reasoning_effort": args.reasoning_effort,
+        "seed_provenance": seed_provenance,
+        # RoboTwin is the only final_only family: a diagnosis produced here is
+        # chunk-granular and must not be compared like-for-like with a
+        # per-step family's.
+        "evidence_granularity": "chunk",
+        "dwell_semantics": describe_dwell_semantics(
+            execute_horizon=args.execute_horizon
+        ),
+    }
+    manifest = CampaignManifest(
+        campaign_id=args.campaign_id,
+        environment=ENVIRONMENT,
+        task=args.task,
+        generation=args.generation,
+        code_commit=args.code_commit,
+        prompt_sha256=file_sha256(prompt_path),
+        model=args.agent_model,
+        tool_catalog_sha256=file_sha256(catalog_path),
+        rollout_seeds=rollout,
+        heldout_seeds=heldout,
+        policy_rng_by_seed=policy_rng,
+        parent_bundle_sha256=parent_sha256,
+        baseline_mode="active_bundle" if parent_sha256 else "strict_pure_vla",
+        active_bundle_sha256=parent_sha256,
+        safety_layer=SafetyLayerConfig(),
+        expected_rollouts=args.rollout_count,
+        expected_heldout=args.heldout_count,
+        initial_logical_slots=args.initial_logical_slots,
+        maximum_logical_slots=args.maximum_logical_slots,
+        continuous_logical_slots=args.continuous_logical_slots,
+        maximum_api_concurrency=args.maximum_api_concurrency,
+        episode_timeout_s=args.episode_timeout_s,
+        no_progress_timeout_s=args.no_progress_timeout_s,
+        target_valid_episodes_per_hour=args.target_valid_episodes_per_hour,
+        max_infrastructure_attempts=args.max_infrastructure_attempts,
+        reasoning_effort=args.reasoning_effort,
+        runtime=runtime,
+    )
+    manifest_path = output / "manifest.json"
+    atomic_write_json(manifest_path, manifest.as_dict(), overwrite=False)
+    preregistration = {
+        "schema_version": 1,
+        "campaign_id": manifest.campaign_id,
+        "manifest_sha256": manifest.sha256,
+        "manifest_file_sha256": file_sha256(manifest_path),
+        "code_commit": args.code_commit,
+        "model": manifest.model,
+        "reasoning_effort": manifest.reasoning_effort,
+        "prompt_sha256": manifest.prompt_sha256,
+        "tool_catalog_sha256": manifest.tool_catalog_sha256,
+        "tool_catalog_digest": DEFAULT_ROBOTWIN_TOOL_CATALOG.digest,
+        "task_binding_digest": binding.digest,
+        "schedule_sha256": canonical_sha256(
+            {
+                "rollout_seeds": rollout,
+                "heldout_seeds": heldout,
+                "policy_rng_by_seed": policy_rng,
+            }
+        ),
+        "rollout_seeds": rollout,
+        "heldout_seeds": heldout,
+        "policy_rng_by_seed": policy_rng,
+        "seed_provenance": seed_provenance,
+        "success_criterion": "authoritative task success only",
+        "baseline_mode": manifest.baseline_mode,
+        "active_bundle_sha256": manifest.active_bundle_sha256,
+        "safety_layer": manifest.safety_layer.as_dict(),
+        "infrastructure_invalid_scored": False,
+        "reuse_rollout_parent_evidence": True,
+        "evidence_granularity": "chunk",
+    }
+    atomic_write_json(output / "preregistration.json", preregistration, overwrite=False)
+    return preregistration
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    Returns:
+        The configured parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="Freeze one RoboTwin evolution campaign"
+    )
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--repository-root", required=True)
+    parser.add_argument("--runtime-python", required=True)
+    parser.add_argument("--code-commit", required=True)
+    parser.add_argument("--task", default="adjust_bottle")
+    parser.add_argument(
+        "--seeds-path",
+        required=True,
+        help="RLinf eval_seeds.json; the curated solvable seeds for the task",
+    )
+    parser.add_argument(
+        "--assets-path",
+        required=True,
+        help="RoboTwin repository root (not its assets/ subdirectory)",
+    )
+    parser.add_argument("--embodiment", nargs="+", default=["aloha-agilex"])
+    parser.add_argument(
+        "--planner-backend", default="mplib", choices=["mplib", "curobo"]
+    )
+    parser.add_argument("--policy-id", required=True)
+    parser.add_argument(
+        "--runtime-url",
+        required=True,
+        help="Shared Rollout Runtime serve endpoint, e.g. http://127.0.0.1:18730",
+    )
+    parser.add_argument("--master-seed", type=int, required=True)
+    parser.add_argument("--rollout-count", type=int, default=50)
+    parser.add_argument("--heldout-count", type=int, default=20)
+    parser.add_argument("--generation", type=int, default=0)
+    parser.add_argument("--parent-bundle", default=None)
+    parser.add_argument("--env-max-steps", type=int, default=200)
+    parser.add_argument("--execute-horizon", type=int, default=25)
+    parser.add_argument("--env-pool-size", type=int, default=4)
+    parser.add_argument("--agent-model", default="gpt-5.6-sol")
+    parser.add_argument("--role1-model", default="gpt-5.6-sol")
+    parser.add_argument("--role1-planner", default="codex", choices=["api", "codex"])
+    parser.add_argument("--reasoning-effort", default="high")
+    parser.add_argument("--initial-logical-slots", type=int, default=4)
+    parser.add_argument("--maximum-logical-slots", type=int, default=4)
+    parser.add_argument("--continuous-logical-slots", type=int, default=4)
+    parser.add_argument("--maximum-api-concurrency", type=int, default=4)
+    parser.add_argument("--episode-timeout-s", type=float, default=1800.0)
+    parser.add_argument("--no-progress-timeout-s", type=float, default=600.0)
+    parser.add_argument("--target-valid-episodes-per-hour", type=float, default=8.0)
+    parser.add_argument("--max-infrastructure-attempts", type=int, default=3)
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint.
+
+    Returns:
+        ``0`` on success.
+    """
+    args = build_parser().parse_args()
+    preregistration = prepare(args)
+    print(json.dumps(preregistration, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/test_env_family_normalization.py
+++ b/tests/runtime/test_env_family_normalization.py
@@ -243,7 +243,7 @@ def test_behavior_table_rejects_unknown_axis_values() -> None:
 
 
 def test_declared_families_cover_the_five_reset_signatures() -> None:
-    """The declared table covers the five reset signatures; robotwin is still declared but not implemented (see the comment below)."""
+    """The declared table covers the four live reset signatures."""
     signatures = {
         behavior.reset_signature for behavior in ENV_FAMILY_BEHAVIORS.values()
     }
@@ -261,20 +261,52 @@ def test_declared_families_cover_the_five_reset_signatures() -> None:
     assert behavior_for("maniskill").needs_accelerator is True
     assert behavior_for(LIBERO_ENV_FAMILY).needs_accelerator is False
     assert behavior_for("robocasa").needs_accelerator is True
-    # robotwin's `robotwin` package does not exist in the validation image, so
-    # it remains "declared but not implemented": what it gets is
-    # UNSUPPORTED_ENV_SPEC + declared=True, not "unknown family".
-    with pytest.raises(RuntimeApiError) as excinfo:
-        get_env_family("robotwin")
-    assert excinfo.value.info.code is ErrorCode.UNSUPPORTED_ENV_SPEC
-    assert excinfo.value.info.detail["declared"] is True
-    # It is also the only ``final_only`` family across all of rlinf; this fact must stay in the declaration table.
+    # robotwin is a CPU subprocess pool too, but SAPIEN will not build a
+    # renderer without a GPU, so it carries the same explicit override.
+    assert behavior_for("robotwin").needs_accelerator is True
+
+
+def test_robotwin_is_the_only_final_only_family() -> None:
+    """``final_only`` exists for robotwin; that fact must stay in the table.
+
+    ``normalize_chunk_outcome``'s whole reason to exist is that one family
+    submits a chunk and sees only its last frame. If this list ever comes back
+    empty, the normalization has lost its only real caller and the guard in
+    ``normalize_chunk_outcome`` is no longer exercised by anything but the
+    ``fake`` backend's impersonation.
+    """
     assert behavior_for("robotwin").chunk_obs_layout == "final_only"
     assert [
         name
         for name, behavior in ENV_FAMILY_BEHAVIORS.items()
         if behavior.chunk_obs_layout == "final_only"
     ] == ["robotwin"]
+
+
+def test_every_declared_family_now_ships_an_adapter() -> None:
+    """No family is declaration-only any more, robotwin included.
+
+    This is the inverse of the assertion this file used to carry: robotwin was
+    declared without an adapter, and ``get_env_family`` was expected to raise
+    ``UNSUPPORTED_ENV_SPEC`` with ``declared=True``. ``rlinf_robotwin.py``
+    closes that gap, so the expectation flips -- every declared family must now
+    resolve to a registered adapter.
+    """
+    from rollout_runtime.backends import ENV_BACKENDS, register_env_family_for
+
+    for name in ENV_FAMILY_BEHAVIORS:
+        assert name in ENV_BACKENDS, f"{name} is declared but has no backend entry"
+        adapter = register_env_family_for(name)
+        assert adapter.env_family == name
+        assert get_env_family(name) is adapter
+
+
+def test_unknown_family_still_reports_unsupported_env_spec() -> None:
+    """The declaration-only path stays live for a future family."""
+    with pytest.raises(RuntimeApiError) as excinfo:
+        get_env_family("not_a_family")
+    assert excinfo.value.info.code is ErrorCode.UNSUPPORTED_ENV_SPEC
+    assert excinfo.value.info.detail["declared"] is False
 
 
 def test_capability_projection_matches_the_behavior() -> None:

--- a/tests/runtime/test_layering.py
+++ b/tests/runtime/test_layering.py
@@ -47,6 +47,7 @@ RUNTIME_INJECTION_POINTS = frozenset(
         "robots/libero/__init__.py",
         "robots/libero/run_evolution_rollout.py",
         "robots/robocasa/run_rollout.py",
+        "robots/robotwin/run_rollout.py",
     }
 )
 """The only files on the zetta / robots side allowed to ``import rollout_runtime``.
@@ -54,6 +55,10 @@ RUNTIME_INJECTION_POINTS = frozenset(
 - ``robots/libero/__init__.py``: the libero family's ``--runtime rollout`` CLI
   switch and ``_init_rollout_runtime``, which does not change the
   ``--runtime legacy`` default path.
+- ``robots/robotwin/run_rollout.py``: the sole integration point for the
+  robotwin family. Everything else under ``robots/robotwin/`` is contract-level
+  (action contract, tool catalog, task bindings) and deliberately stays
+  simulator- and runtime-free so it imports in the minimal test environment.
 - ``robots/robocasa/run_rollout.py``: the sole integration point for runtime
   v3. The robocasa side has **no** legacy/rollout dual-path option: direct
   calls to ``RoboCasaEnvClient``/``Gr00tClient`` have been fully replaced, and
@@ -77,6 +82,7 @@ RUNTIME_TOOLING_FILES = frozenset(
         "scripts/deployment/m7_acceptance/rr_eval_batching.py",
         "scripts/deployment/m7_acceptance/rr_serve_overhead.py",
         "scripts/deployment/smoke_cosmos_lite.py",
+        "scripts/deployment/visualize_robotwin_episode.py",
         "scripts/experiments/run_ab_runtime.py",
         "scripts/experiments/run_concurrency_ab.py",
         "scripts/experiments/libero_critic_recovery_latency_v3.py",

--- a/tests/runtime/test_robotwin_family.py
+++ b/tests/runtime/test_robotwin_family.py
@@ -1,0 +1,451 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The robotwin family: ``final_only`` normalization and the D1/D3 mappings.
+
+``.venv-runtime`` has no ``robotwin`` package or SAPIEN, so a stub env drives
+the **real** ``RobotwinEnvCore``. What that pins down locally is exactly the
+part that is ours rather than the simulator's: that a submitted chunk produces
+no per-step records, that the left/right wrist frames land in the fields the
+policy expects, that the open-loop execute horizon truncates instead of
+silently over-running, and that the capability table matches the behaviour.
+
+What the stub cannot cover is whether these parameters actually boot RoboTwin;
+that is the GPU smoke test's job (``plan/robotwin_s0_findings.md``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from rollout_runtime.api.enums import ErrorCode
+from rollout_runtime.api.errors import RuntimeApiError
+from rollout_runtime.api.messages import EnvSpecMsg, ResetSpec
+from rollout_runtime.core import payload as payload_module
+from rollout_runtime.core.env_execution import LOCKSTEP_VECTOR_FORM, PER_SLOT_FORM
+from rollout_runtime.core.env_registry import behavior_for
+
+ACTION_DIM = 14
+IMAGE_H = 6
+IMAGE_W = 8
+MAIN_FILL = 33
+LEFT_FILL = 11
+RIGHT_FILL = 22
+
+
+def _frame(fill: int) -> np.ndarray:
+    """Build a uniformly filled uint8 RGB frame.
+
+    Args:
+        fill: The fill value, used to tell the three views apart.
+
+    Returns:
+        An ``IMAGE_H x IMAGE_W x 3`` uint8 array.
+    """
+    return np.full((IMAGE_H, IMAGE_W, 3), fill, dtype=np.uint8)
+
+
+class _StubRoboTwinEnv:
+    """Stand-in for the vendored ``RoboTwinEnv``.
+
+    Reproduces the parts of the contract the adapter depends on: the
+    ``reset(env_idx, env_seeds)`` signature, and a ``chunk_step`` that consumes
+    the whole chunk and returns a **length-1** ``obs_list`` alongside
+    chunk-shaped reward/flag matrices whose only populated column is the last.
+    """
+
+    instances: list[_StubRoboTwinEnv] = []
+
+    def __init__(
+        self,
+        cfg: Any,
+        num_envs: int,
+        seed_offset: int,
+        total_num_processes: int,
+        worker_info: Any,
+        record_metrics: bool = True,
+    ) -> None:
+        """Record construction arguments and register the instance."""
+        self.cfg = cfg
+        self.num_envs = num_envs
+        self.seed_offset = seed_offset
+        self.total_num_processes = total_num_processes
+        self.is_start = True
+        self.reset_calls: list[tuple[Any, Any]] = []
+        self.chunk_calls: list[np.ndarray] = []
+        self.closed = False
+        self.wrist_names = ["left_wrist_image", "right_wrist_image"]
+        self.terminate = False
+        type(self).instances.append(self)
+
+    def _payload(self) -> dict[str, Any]:
+        """Build one observation payload in the family's own layout.
+
+        Returns:
+            The 4-key payload plus the additive ``wrist_image_names``.
+        """
+        fills = {"left_wrist_image": LEFT_FILL, "right_wrist_image": RIGHT_FILL}
+        wrist_stack = (
+            np.stack([_frame(fills[name]) for name in self.wrist_names])[None, ...]
+            if self.wrist_names
+            else None
+        )
+        return {
+            "main_images": _frame(MAIN_FILL)[None, ...],
+            "wrist_images": wrist_stack,
+            # float64 on purpose: this is what RoboTwin really returns, and the
+            # adapter must land it as float32 in the Observation.
+            "states": np.arange(ACTION_DIM, dtype=np.float64)[None, ...],
+            "task_descriptions": ["pick the bottle with the correct arm"],
+            "wrist_image_names": list(self.wrist_names),
+        }
+
+    def reset(self, env_idx: Any = None, env_seeds: Any = None):
+        """Record the reset and return the initial payload."""
+        self.reset_calls.append(
+            (env_idx, None if env_seeds is None else list(env_seeds))
+        )
+        return self._payload(), {}
+
+    def chunk_step(self, chunk_actions: Any):
+        """Consume the whole chunk and return a single final frame."""
+        array = np.asarray(chunk_actions)
+        self.chunk_calls.append(array)
+        chunk = int(array.shape[1])
+        rewards = np.zeros((1, chunk), dtype=np.float32)
+        rewards[0, -1] = 1.5
+        terminations = np.zeros((1, chunk), dtype=bool)
+        truncations = np.zeros((1, chunk), dtype=bool)
+        if self.terminate:
+            terminations[0, -1] = True
+        infos = [{"success": np.array([self.terminate])}]
+        return [self._payload()], rewards, terminations, truncations, infos
+
+    def offload(self, clear_cache: bool = True) -> None:
+        """Mark the env released."""
+        self.closed = True
+
+
+@pytest.fixture
+def robotwin_backend(monkeypatch: pytest.MonkeyPatch):
+    """Point the adapter's lazy env lookup at the stub.
+
+    Args:
+        monkeypatch: pytest's patcher.
+
+    Returns:
+        The backend module.
+    """
+    import rollout_runtime.backends.rlinf_robotwin as backend_module
+
+    _StubRoboTwinEnv.instances = []
+    monkeypatch.setattr(backend_module, "_robotwin_env_class", lambda: _StubRoboTwinEnv)
+    return backend_module
+
+
+def robotwin_spec(pool_size: int = 1, **overrides: Any) -> EnvSpecMsg:
+    """Build a robotwin env spec.
+
+    Args:
+        pool_size: Pool capacity (unused by the spec itself, kept for parity).
+        **overrides: ``env_config`` overrides.
+
+    Returns:
+        The env spec.
+    """
+    config: dict[str, Any] = {
+        "task_name": "adjust_bottle",
+        "assets_path": "/workspace/RoboTwin",
+        "action_dim": ACTION_DIM,
+        "chunk_size": 4,
+    }
+    config.update(overrides)
+    return EnvSpecMsg(env_family="robotwin", env_config=config)
+
+
+def _build(backend_module, *, num_envs: int = 1, **overrides: Any):
+    """Build a core against the stub.
+
+    Args:
+        backend_module: The adapter module.
+        num_envs: Pool size.
+        **overrides: ``env_config`` overrides.
+
+    Returns:
+        The built core.
+    """
+    core = backend_module.RobotwinEnvCore()
+    core.build(robotwin_spec(**overrides), num_envs=num_envs)
+    return core
+
+
+# ------------------------------------------------------------------ behaviour
+
+
+def test_declaration_matches_the_measured_family() -> None:
+    """The six axes are what was verified against RLinf 9ad44393 on hardware."""
+    behavior = behavior_for("robotwin")
+    assert behavior.chunk_obs_layout == "final_only"
+    assert behavior.per_step_obs_available is False
+    assert behavior.reset_signature == "env_idx_env_seeds"
+    assert behavior.action_layout == "numpy_env_chunk_dim"
+    assert behavior.needs_accelerator is True, "SAPIEN cannot render without a GPU"
+    assert behavior.core_forms == frozenset({PER_SLOT_FORM})
+    assert behavior.supports_coalescing is False
+    assert behavior.max_pool_size == 16
+
+
+def test_capability_declares_reset_state_ids(robotwin_backend) -> None:
+    """RoboTwin's ``env_seeds`` *is* a reset-state selector, so it is declared.
+
+    This is the opposite call from maniskill, where ``reset_state_id`` is
+    accepted by the signature but ignored by most tasks. Here the seed fully
+    determines the scene, and the campaign protocol's paired same-seed gate
+    depends on being able to pin it.
+    """
+    capability = robotwin_backend.robotwin_env_capability()
+    assert capability.env_family == "robotwin"
+    assert capability.supports_reset_state_id is True
+    assert capability.per_step_obs_available is False
+    assert capability.needs_accelerator is True
+    assert capability.supports_auto_reset is False
+    assert capability.extensions == frozenset()
+
+
+def test_lockstep_form_is_rejected(robotwin_backend) -> None:
+    """Only ``per_slot`` is declared, so asking for a vector pool is an error."""
+    core = robotwin_backend.RobotwinEnvCore()
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.build(robotwin_spec(core_form=LOCKSTEP_VECTOR_FORM), num_envs=1)
+    assert excinfo.value.info.code is ErrorCode.INVALID_ARGUMENT
+
+
+def test_pool_size_is_capped_at_the_measured_ceiling(robotwin_backend) -> None:
+    """The SAPIEN buffer ceiling is a declared limit, not a runtime surprise."""
+    core = robotwin_backend.RobotwinEnvCore()
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.build(robotwin_spec(), num_envs=17)
+    assert excinfo.value.info.code is ErrorCode.INVALID_ARGUMENT
+    assert excinfo.value.info.detail["max_pool_size"] == 16
+
+
+def test_chunk_step_produces_no_per_step_records(robotwin_backend) -> None:
+    """``final_only``: one submitted chunk, one frame, no per-step records.
+
+    This is the whole reason ``normalize_chunk_outcome`` exists. ``per_step``
+    must be ``None`` -- not an empty list, which downstream code would read as
+    "records exist and there were none".
+    """
+    core = _build(robotwin_backend)
+    core.reset([0], ResetSpec(seed=123))
+    outcome = core.chunk_step([0], [np.zeros((4, ACTION_DIM), dtype=np.float32)])[0]
+
+    assert outcome.per_step is None
+    assert outcome.per_step_obs_available is False
+    assert outcome.executed_horizon == 4
+    assert outcome.reward == pytest.approx(1.5)
+    assert outcome.info["chunk_obs_layout"] == "final_only"
+    # The family got the whole chunk in a single call.
+    env = _StubRoboTwinEnv.instances[0]
+    assert len(env.chunk_calls) == 1
+    assert env.chunk_calls[0].shape == (1, 4, ACTION_DIM)
+
+
+def test_wrist_views_are_split_by_name_not_position(robotwin_backend) -> None:
+    """D1: left wrist -> ``wrist_image``, right wrist -> ``extra_view_images[0]``.
+
+    The mapping reads the family's ``wrist_image_names``. Getting it backwards
+    would not raise anywhere -- it would just hand the policy a mirrored view --
+    so it is pinned by comparing against the exact encoded frames.
+    """
+    core = _build(robotwin_backend)
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+
+    assert observation.main_image == payload_module.encode_image(_frame(MAIN_FILL))
+    assert observation.wrist_image == payload_module.encode_image(_frame(LEFT_FILL))
+    assert len(observation.extra_view_images) == 1
+    assert observation.extra_view_images[0] == payload_module.encode_image(
+        _frame(RIGHT_FILL)
+    )
+
+
+def test_wrist_split_follows_a_right_only_configuration(robotwin_backend) -> None:
+    """A right-wrist-only stack must not be mistaken for a left wrist.
+
+    Upstream stacks whichever wrists exist, so slice 0 is the right wrist here.
+    Position-based mapping would silently put it in ``wrist_image``.
+    """
+    core = _build(robotwin_backend)
+    env = _StubRoboTwinEnv.instances[0]
+    env.wrist_names = ["right_wrist_image"]
+
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+    assert observation.wrist_image is None
+    assert observation.extra_view_images[0] == payload_module.encode_image(
+        _frame(RIGHT_FILL)
+    )
+
+
+def test_no_wrist_cameras_yields_no_wrist_views(robotwin_backend) -> None:
+    """``collect_wrist_camera: false`` must degrade cleanly, not crash."""
+    core = _build(robotwin_backend)
+    env = _StubRoboTwinEnv.instances[0]
+    env.wrist_names = []
+
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+    assert observation.wrist_image is None
+    assert observation.extra_view_images == []
+
+
+def test_state_is_float32_even_though_robotwin_returns_float64(
+    robotwin_backend,
+) -> None:
+    """RoboTwin's ``state`` is float64; the schema digest compares dtypes."""
+    core = _build(robotwin_backend)
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+    assert len(observation.state) == ACTION_DIM
+    assert all(isinstance(value, float) for value in observation.state)
+    assert observation.state[:3] == [0.0, 1.0, 2.0]
+
+
+def test_execute_horizon_truncates_the_submitted_chunk(robotwin_backend) -> None:
+    """D3: the model may emit 50 actions while only the first N are executed.
+
+    The discard is the configured open-loop replan, so it must be visible in
+    the outcome rather than inferred from a length mismatch.
+    """
+    core = _build(robotwin_backend, execute_horizon=3)
+    core.reset([0], ResetSpec(seed=1))
+    outcome = core.chunk_step([0], [np.zeros((10, ACTION_DIM), dtype=np.float32)])[0]
+
+    env = _StubRoboTwinEnv.instances[0]
+    assert env.chunk_calls[0].shape == (1, 3, ACTION_DIM)
+    assert outcome.executed_horizon == 3
+    assert outcome.info["requested_horizon"] == 10
+    assert outcome.info["discarded_actions"] == 7
+    assert core.total_discarded_actions == 7
+
+
+def test_execute_horizon_leaves_a_short_chunk_alone(robotwin_backend) -> None:
+    """A chunk shorter than the horizon is submitted whole, with no discard."""
+    core = _build(robotwin_backend, execute_horizon=8)
+    core.reset([0], ResetSpec(seed=1))
+    outcome = core.chunk_step([0], [np.zeros((2, ACTION_DIM), dtype=np.float32)])[0]
+    assert outcome.executed_horizon == 2
+    assert "discarded_actions" not in outcome.info
+
+
+def test_reset_state_id_wins_over_seed(robotwin_backend) -> None:
+    """Seed precedence: ``reset_state_id`` > ``seed`` > the family's schedule."""
+    core = _build(robotwin_backend)
+    env = _StubRoboTwinEnv.instances[0]
+
+    core.reset([0], ResetSpec(seed=7, reset_state_id=4242))
+    assert env.reset_calls[-1] == (None, [4242])
+
+    core.reset([0], ResetSpec(seed=7))
+    assert env.reset_calls[-1] == (None, [7])
+
+    core.reset([0], ResetSpec())
+    assert env.reset_calls[-1] == (None, None)
+
+
+def test_termination_freezes_the_lane(robotwin_backend) -> None:
+    """A terminating chunk sets the flag and stops the lane."""
+    core = _build(robotwin_backend)
+    core.reset([0], ResetSpec(seed=1))
+    _StubRoboTwinEnv.instances[0].terminate = True
+
+    outcome = core.chunk_step([0], [np.zeros((4, ACTION_DIM), dtype=np.float32)])[0]
+    assert outcome.terminated is True
+    assert outcome.info["success"] is True
+    assert core.lane_status([0])[0].terminated is True
+
+
+def test_wrong_action_width_is_rejected(robotwin_backend) -> None:
+    """A 7-dim single-arm chunk reaching a bimanual env must fail loudly."""
+    core = _build(robotwin_backend)
+    core.reset([0], ResetSpec(seed=1))
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.chunk_step([0], [np.zeros((4, 7), dtype=np.float32)])
+    assert excinfo.value.info.code is ErrorCode.INVALID_ARGUMENT
+
+
+def test_chunk_step_before_reset_is_rejected(robotwin_backend) -> None:
+    """Stepping an un-reset slot is ``SESSION_NOT_READY``, not a crash."""
+    core = _build(robotwin_backend)
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.chunk_step([0], [np.zeros((4, ACTION_DIM), dtype=np.float32)])
+    assert excinfo.value.info.code is ErrorCode.SESSION_NOT_READY
+
+
+def test_extensions_are_declaratively_rejected(robotwin_backend) -> None:
+    """The family declares no extensions, so every call is refused cleanly."""
+    core = _build(robotwin_backend)
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.extension(0, "robotwin", "snapshot", {})
+    assert excinfo.value.info.code is ErrorCode.UNSUPPORTED_EXTENSION
+
+
+def test_unknown_config_keys_are_rejected(robotwin_backend) -> None:
+    """A typo would otherwise allocate a second SAPIEN pool via the digest."""
+    with pytest.raises(RuntimeApiError) as excinfo:
+        robotwin_backend.RobotwinEnvConfig.from_mapping(
+            {"assets_path": "/x", "taskname": "adjust_bottle"}
+        )
+    assert excinfo.value.info.code is ErrorCode.INVALID_ARGUMENT
+    assert excinfo.value.info.detail["unknown_keys"] == ["taskname"]
+
+
+def test_missing_assets_path_is_rejected(robotwin_backend) -> None:
+    """``assets_path`` has no sensible default and its absence fails late."""
+    with pytest.raises(RuntimeApiError):
+        robotwin_backend.RobotwinEnvConfig.from_mapping({"task_name": "adjust_bottle"})
+
+
+def test_task_config_defaults_to_mplib_and_disables_data_collection(
+    robotwin_backend,
+) -> None:
+    """The planner default is mplib, and the family must not write its own data."""
+    config = robotwin_backend.RobotwinEnvConfig.from_mapping(
+        {"assets_path": "/workspace/RoboTwin"}
+    )
+    task_config = config.task_config()
+    assert task_config["planner_backend"] == "mplib"
+    assert task_config["collect_data"] is False
+    assert task_config["camera"]["collect_wrist_camera"] is True
+
+
+def test_pool_builds_one_env_per_slot(robotwin_backend) -> None:
+    """``per_slot``: N slots means N single-lane envs, each seeded distinctly."""
+    core = _build(robotwin_backend, num_envs=3)
+    assert len(_StubRoboTwinEnv.instances) == 3
+    assert [env.num_envs for env in _StubRoboTwinEnv.instances] == [1, 1, 1]
+    assert [env.seed_offset for env in _StubRoboTwinEnv.instances] == [0, 1, 2]
+    # The family's "first reset decides its own state" branch must be off.
+    assert all(env.is_start is False for env in _StubRoboTwinEnv.instances)
+
+    core.close()
+    # SAPIEN teardown segfaults, so `close` drops references without calling it.
+    assert all(env.closed is False for env in _StubRoboTwinEnv.instances)
+
+
+def test_close_does_not_tear_down_sapien_by_default(robotwin_backend) -> None:
+    """A segfaulting teardown would turn `close_sessions` into a worker restart.
+
+    ``VectorEnv.close()`` crashes the process during SAPIEN teardown, and a
+    segfault cannot be caught, so the pool releases its references instead and
+    lets the subprocesses go when the worker exits.
+    """
+    core = _build(robotwin_backend)
+    core.close()
+    assert core.closed is True
+    assert _StubRoboTwinEnv.instances[0].closed is False
+
+
+def test_teardown_on_close_is_available_as_an_escape_hatch(robotwin_backend) -> None:
+    """The real teardown stays reachable for a RoboTwin build that fixed it."""
+    core = _build(robotwin_backend, teardown_on_close=True)
+    core.close()
+    assert _StubRoboTwinEnv.instances[0].closed is True

--- a/tests/runtime/test_robotwin_policy_contract.py
+++ b/tests/runtime/test_robotwin_policy_contract.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The robotwin policy path: camera contract and the shipped preset (S3).
+
+Two classes of silent breakage are pinned here.
+
+The **camera contract**: RoboTwin gives three views (head, left wrist, right
+wrist) and ``pi05_aloha_robotwin`` is built with ``num_images_in_input: 3``.
+The Runtime carries them as ``main_image`` + ``wrist_image`` +
+``extra_view_images[0]``, and that structure enters ``obs_schema_digest``,
+which in turn enters the inference ``compat_key``. Losing a view does not
+raise anywhere -- it silently changes the batching bucket and feeds the model
+a different observation than it was trained on -- so the digest is asserted to
+*change* when the layout changes and to *hold* when only pixels do.
+
+The **preset**: ``load_config`` validates the runtime skeleton but never looks
+inside ``env_config``/``policy_config``, so a preset can name a field that no
+backend accepts and only fail on a GPU host minutes into a deploy. These tests
+parse both blocks with the real backend configs and cross-check the handful of
+values that have to agree between the env and the policy.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rollout_runtime.api.messages import ResetSpec
+from rollout_runtime.config.schema import load_config
+from rollout_runtime.core.obs_schema import (
+    obs_schema_digest,
+    observations_to_env_output,
+)
+from tests.runtime.test_robotwin_family import (
+    ACTION_DIM,
+    LEFT_FILL,
+    RIGHT_FILL,
+    _StubRoboTwinEnv,
+    _build,
+    _frame,
+    robotwin_backend,  # noqa: F401 - fixture re-export
+)
+
+PRESET = "robotwin_pi05"
+
+
+# ------------------------------------------------------------ camera contract
+
+
+def test_three_views_survive_into_the_five_key_env_output(robotwin_backend) -> None:  # noqa: F811
+    """All three RoboTwin cameras reach the policy-facing batch dict.
+
+    ``observations_to_env_output`` is what the policy backend actually reads.
+    If the right wrist were dropped on the way, ``num_images_in_input: 3``
+    would still be configured and the model would be fed a short stack.
+    """
+    core = _build(robotwin_backend)
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+    output = observations_to_env_output([observation])
+
+    assert output["main_images"] is not None
+    assert output["wrist_images"] is not None
+    assert output["extra_view_images"] is not None
+    assert output["task_descriptions"] == ["pick the bottle with the correct arm"]
+    assert np.asarray(output["states"]).shape == (1, ACTION_DIM)
+
+
+def test_schema_digest_changes_when_a_view_disappears(robotwin_backend) -> None:  # noqa: F811
+    """Dropping the right wrist must change the compat bucket, not pass silently."""
+    core = _build(robotwin_backend)
+    both = obs_schema_digest(core.reset([0], ResetSpec(seed=1))[0])
+
+    _StubRoboTwinEnv.instances[0].wrist_names = ["left_wrist_image"]
+    left_only = obs_schema_digest(core.reset([0], ResetSpec(seed=1))[0])
+
+    _StubRoboTwinEnv.instances[0].wrist_names = []
+    none_at_all = obs_schema_digest(core.reset([0], ResetSpec(seed=1))[0])
+
+    assert len({both, left_only, none_at_all}) == 3
+
+
+def test_schema_digest_is_stable_across_pixel_changes(robotwin_backend) -> None:  # noqa: F811
+    """The digest is structural: same shapes, same bucket, different content.
+
+    Without this the digest would be content-sensitive and every frame would
+    open its own batching bucket, quietly destroying inference batching.
+    """
+    core = _build(robotwin_backend)
+    first = obs_schema_digest(core.reset([0], ResetSpec(seed=1))[0])
+    core.chunk_step([0], [np.zeros((4, ACTION_DIM), dtype=np.float32)])
+    second = obs_schema_digest(core.observe([0])[0])
+    assert first == second
+
+
+def test_left_and_right_wrists_are_not_interchangeable(robotwin_backend) -> None:  # noqa: F811
+    """A mirrored wrist mapping is invisible to the schema, so pin the bytes.
+
+    Both orderings produce the *same* digest -- identical shapes in identical
+    fields -- which is exactly why the digest cannot be the only guard here.
+    """
+    from rollout_runtime.core import payload as payload_module
+
+    core = _build(robotwin_backend)
+    straight = core.reset([0], ResetSpec(seed=1))[0]
+
+    _StubRoboTwinEnv.instances[0].wrist_names = [
+        "right_wrist_image",
+        "left_wrist_image",
+    ]
+    swapped = core.reset([0], ResetSpec(seed=1))[0]
+
+    assert obs_schema_digest(straight) == obs_schema_digest(swapped)
+    # ... and the adapter still routes by name, so the frames do not move.
+    for observation in (straight, swapped):
+        assert observation.wrist_image == payload_module.encode_image(_frame(LEFT_FILL))
+        assert observation.extra_view_images[0] == payload_module.encode_image(
+            _frame(RIGHT_FILL)
+        )
+
+
+# -------------------------------------------------------------------- preset
+
+
+def test_preset_env_config_parses_with_the_real_backend() -> None:
+    """``load_config`` never validates ``env_config``; this does."""
+    from rollout_runtime.backends.rlinf_robotwin import RobotwinEnvConfig
+
+    config = load_config(PRESET)
+    assert config.env_family == "robotwin"
+    env_config = RobotwinEnvConfig.from_mapping(config.env_config)
+    assert env_config.task_name == "adjust_bottle"
+    assert env_config.planner_backend == "mplib"
+    assert env_config.action_dim == ACTION_DIM
+
+
+def test_preset_policy_config_parses_with_the_real_backend() -> None:
+    """A preset naming a field no backend accepts must fail here, not on a GPU host."""
+    from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig
+
+    config = load_config(PRESET)
+    policy = RlinfPolicyConfig.from_mapping(config.rollout_worker.policy_config)
+    assert policy.model_type == "openpi"
+    assert policy.action_dim == ACTION_DIM
+    assert policy.family_params["config_name"] == "pi05_aloha_robotwin"
+
+
+def test_preset_matches_the_rlinf_baseline_configuration() -> None:
+    """The values that produced the S0 baseline must not drift silently.
+
+    ``plan/robotwin_s0_findings.md`` records success_once=0.9375 for RLinf's
+    own eval at these settings. S3 compares against that number, so a change
+    to any of them invalidates the comparison and should be a deliberate edit.
+    """
+    from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig
+
+    policy = RlinfPolicyConfig.from_mapping(
+        load_config(PRESET).rollout_worker.policy_config
+    )
+    assert policy.num_action_chunks == 50
+    assert policy.num_steps == 5
+    assert policy.family_params["num_images_in_input"] == 3
+    assert policy.family_params["noise_level"] == 0.3
+
+    model_cfg = policy.to_model_cfg()
+    # `to_model_cfg` derives these; the model is built from them, not from the
+    # checkpoint's own config.json (which carries a stale action_horizon: 10).
+    assert model_cfg.openpi.action_chunk == 50
+    assert model_cfg.openpi.action_env_dim == ACTION_DIM
+
+
+def test_preset_env_and_policy_agree_on_the_shared_values() -> None:
+    """Env and policy are configured separately but must describe one robot."""
+    from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig
+    from rollout_runtime.backends.rlinf_robotwin import RobotwinEnvConfig
+
+    config = load_config(PRESET)
+    env_config = RobotwinEnvConfig.from_mapping(config.env_config)
+    policy = RlinfPolicyConfig.from_mapping(config.rollout_worker.policy_config)
+
+    assert env_config.action_dim == policy.action_dim, "one robot, one action width"
+    # Three model inputs require the wrist cameras to actually be rendered.
+    assert env_config.collect_wrist_camera is True
+    assert env_config.collect_head_camera is True
+    assert policy.family_params["num_images_in_input"] == 3
+    # D3: the executed horizon is an open-loop truncation of the model's chunk,
+    # so it can never exceed it.
+    assert env_config.execute_horizon is not None
+    assert env_config.execute_horizon <= policy.num_action_chunks
+
+
+def test_preset_pool_sizes_respect_the_measured_sapien_ceiling() -> None:
+    """24 GB cards cannot host more than 16 concurrent RoboTwin envs, machine-wide."""
+    from rollout_runtime.core.env_registry import behavior_for
+
+    config = load_config(PRESET)
+    ceiling = behavior_for("robotwin").max_pool_size
+    assert ceiling is not None
+    assert config.env_worker.default_pool_size <= ceiling
+    assert config.env_worker.max_sessions_per_rank <= ceiling
+    # SAPIEN needs a GPU, so the env group must not use the `node` strategy --
+    # that infers has_accelerator=False and the registry refuses to schedule.
+    assert config.env_worker.placement_strategy == "packed"
+
+
+def test_preset_carries_no_real_machine_paths() -> None:
+    """Presets ship placeholders; a real checkpoint path would leak a host layout."""
+    config = load_config(PRESET)
+    assert config.env_config["assets_path"].startswith("/path/to/")
+    assert config.rollout_worker.policy_config["model_path"].startswith("/path/to/")
+
+
+# ------------------------------------------------------- wrist re-stacking
+
+
+def test_stack_wrist_views_rebuilds_the_aloha_pair() -> None:
+    """The split in the env adapter and this re-stack are a matched pair.
+
+    ``aloha_policy._decode_aloha`` reads the left and right wrist as
+    ``wrist_images[0]`` / ``wrist_images[1]`` and never touches
+    ``extra_view_image``. The Runtime's ``Observation`` cannot carry a stacked
+    pair, so the pair is reassembled here, right before the forward pass.
+    """
+    from rollout_runtime.backends.rlinf_policy import _stack_wrist_views
+
+    left = np.zeros((2, 4, 5, 3), dtype=np.uint8)
+    right = np.ones((2, 1, 4, 5, 3), dtype=np.uint8)
+    stacked = _stack_wrist_views({"wrist_images": left, "extra_view_images": right})
+
+    assert stacked["wrist_images"].shape == (2, 2, 4, 5, 3)
+    assert stacked["extra_view_images"] is None
+    # Order matters: index 0 must stay the left wrist.
+    assert stacked["wrist_images"][0, 0].max() == 0
+    assert stacked["wrist_images"][0, 1].min() == 1
+
+
+def test_stack_wrist_views_is_a_noop_without_both_views() -> None:
+    """Safe to leave enabled for a single-wrist configuration."""
+    from rollout_runtime.backends.rlinf_policy import _stack_wrist_views
+
+    only_wrist = {"wrist_images": np.zeros((1, 4, 5, 3)), "extra_view_images": None}
+    assert _stack_wrist_views(only_wrist) is only_wrist
+
+    neither = {"wrist_images": None, "extra_view_images": None}
+    assert _stack_wrist_views(neither) is neither
+
+
+def test_preset_enables_wrist_restacking() -> None:
+    """RoboTwin + ALOHA needs it; forgetting the flag fails silently at inference.
+
+    Without it the model receives a single ``[H, W, C]`` wrist frame and indexes
+    row 0 and row 1 out of its *height*, which surfaces only as a channel-count
+    mismatch inside the vision tower.
+    """
+    from rollout_runtime.backends.rlinf_policy import RlinfPolicyConfig
+    from rollout_runtime.backends.rlinf_robotwin import RobotwinEnvConfig
+
+    config = load_config(PRESET)
+    policy = RlinfPolicyConfig.from_mapping(config.rollout_worker.policy_config)
+    env_config = RobotwinEnvConfig.from_mapping(config.env_config)
+
+    assert policy.stack_wrist_views is True
+    # Only meaningful when the env actually renders both wrists.
+    assert env_config.collect_wrist_camera is True
+
+
+def test_stacked_wrists_round_trip_from_the_env_adapter(robotwin_backend) -> None:  # noqa: F811
+    """End to end: adapter splits the pair, the policy helper puts it back.
+
+    This is the invariant that the real hardware run broke, so it is asserted
+    on the actual observation the adapter produces rather than on a synthetic
+    tensor.
+    """
+    from rollout_runtime.backends.rlinf_policy import _stack_wrist_views
+
+    core = _build(robotwin_backend)
+    observation = core.reset([0], ResetSpec(seed=1))[0]
+    env_obs = observations_to_env_output([observation])
+
+    stacked = _stack_wrist_views(env_obs)["wrist_images"]
+    assert stacked.shape[:2] == (1, 2)
+    assert int(np.asarray(stacked)[0, 0].flat[0]) == LEFT_FILL
+    assert int(np.asarray(stacked)[0, 1].flat[0]) == RIGHT_FILL

--- a/tests/runtime/test_robotwin_run_rollout.py
+++ b/tests/runtime/test_robotwin_run_rollout.py
@@ -1,0 +1,938 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The RoboTwin rollout entrypoint, driven against a fake Runtime client.
+
+No simulator and no HTTP: the point is the wiring the campaign depends on --
+that the episode seed reaches the family as a **reset-state id** (RoboTwin's
+seed *is* its scene), that the chunk loop tolerates a ``final_only`` family
+returning no per-step records, and that the resulting ``EpisodeRecord`` carries
+the digests a manifest is checked against.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from robots.robotwin.run_rollout import build_parser, run
+from robots.robotwin.tool_bindings import binding_for_task
+from robots.robotwin.tool_catalog import DEFAULT_ROBOTWIN_TOOL_CATALOG
+from rollout_runtime.api.ids import EpisodeId, RequestId, SessionId
+from rollout_runtime.api.messages import Observation, StepResult
+from rollout_runtime.api.result import Ok
+from rollout_runtime.core.payload import decode_array, encode_array, encode_image
+
+ENV_SPEC_DIGEST = "digest-robotwin-test"
+
+
+class _FakeClient:
+    """A Runtime client that ends the episode after a fixed number of chunks."""
+
+    def __init__(
+        self,
+        *,
+        chunks_until_done: int = 3,
+        succeed: bool = True,
+        with_images: bool = False,
+    ) -> None:
+        """Configure the fake.
+
+        Args:
+            chunks_until_done: How many chunks before termination is reported.
+            succeed: Whether the final chunk reports success.
+            with_images: Whether observations carry the three camera views.
+        """
+        self.chunks_until_done = chunks_until_done
+        self.succeed = succeed
+        self.with_images = with_images
+        self.created: list[Any] = []
+        self.reset_specs: list[Any] = []
+        self.policy_requests: list[Any] = []
+        self.chunk_calls = 0
+        self.infer_calls = 0
+        self.action_steps: list[Any] = []
+        self.closed = False
+
+    async def create_sessions(self, requests):
+        """Record the request and hand back a session handle."""
+        self.created.extend(requests)
+        return [
+            Ok(
+                value=SimpleNamespace(
+                    session_id=SessionId("session-1"),
+                    env_spec_digest=ENV_SPEC_DIGEST,
+                    lease_expiration=1e12,
+                )
+            )
+        ]
+
+    def _observation(self) -> Observation:
+        """Build a chunk-final observation carrying a state and three views."""
+        state = [0.01 * self.chunk_calls] * 14
+        frame = np.full((4, 6, 3), self.chunk_calls % 256, dtype=np.uint8)
+        images = (
+            {
+                "main_image": encode_image(frame),
+                "wrist_image": encode_image(frame),
+                "extra_view_images": [encode_image(frame)],
+            }
+            if self.with_images
+            else {}
+        )
+        return Observation(
+            session_id=SessionId("session-1"),
+            episode_id=EpisodeId(0),
+            step_index=self.chunk_calls,
+            state=state,
+            instruction="lift the bottle with the correct arm",
+            **images,
+        )
+
+    async def policy_infer(self, ids, policy_request):
+        """Return a [chunk, 14] proposal without touching the environment."""
+        self.policy_requests.append(policy_request)
+        self.infer_calls += 1
+        block = np.full((2, 14), 0.05, dtype=np.float32)
+        return [
+            Ok(
+                value=SimpleNamespace(
+                    actions=encode_array(block), model_version="pi05-test"
+                )
+            )
+        ]
+
+    async def action_step(self, ids, actions):
+        """Execute a chunk Role1 already reviewed.
+
+        ``executed_horizon`` reports the number of actions actually submitted,
+        which is what the real adapter does: the env executes what it is given,
+        capped by ``execute_horizon``. Reporting a fixed number here instead
+        would let the rollout's action step indices drift from its chunk step
+        indices without any test noticing.
+        """
+        self.action_steps.append(actions)
+        self.chunk_calls += 1
+        submitted = int(np.asarray(decode_array(actions[0])).shape[0])
+        done = self.chunk_calls >= self.chunks_until_done
+        return [
+            Ok(
+                value=StepResult(
+                    request_id=RequestId(f"act-{self.chunk_calls}"),
+                    session_id=ids[0],
+                    observation=self._observation(),
+                    reward=0.0,
+                    terminated=done,
+                    executed_horizon=submitted,
+                    per_step=None,
+                    info={
+                        "executed_horizon": submitted,
+                        "requested_horizon": 50,
+                        "success": bool(done and self.succeed),
+                    },
+                )
+            )
+        ]
+
+    async def reset(self, ids, reset_spec):
+        """Record the reset spec and return the initial frame."""
+        self.reset_specs.append(reset_spec)
+        return [
+            Ok(
+                value=StepResult(
+                    request_id=RequestId("reset-1"),
+                    session_id=ids[0],
+                    observation=self._observation(),
+                    info={},
+                )
+            )
+        ]
+
+    async def policy_step(self, ids, policy_request):
+        """Return a chunk-granular step result, never a per-step one."""
+        self.policy_requests.append(policy_request)
+        self.chunk_calls += 1
+        done = self.chunk_calls >= self.chunks_until_done
+        return [
+            Ok(
+                value=StepResult(
+                    request_id=RequestId(f"chunk-{self.chunk_calls}"),
+                    session_id=ids[0],
+                    observation=self._observation(),
+                    reward=1.0 if done and self.succeed else 0.0,
+                    terminated=done,
+                    executed_horizon=25,
+                    # final_only: the family produces no intermediate frames.
+                    per_step=None,
+                    info={
+                        "executed_horizon": 25,
+                        "requested_horizon": 50,
+                        "discarded_actions": 25,
+                        "success": bool(done and self.succeed),
+                    },
+                )
+            )
+        ]
+
+    async def renew_sessions(self, ids, lease_seconds):
+        """Renew the lease."""
+        return [Ok(value=SimpleNamespace(lease_expiration=1e12))]
+
+    async def close_sessions(self, ids):
+        """Close the session."""
+        self.closed = True
+        return [Ok(value={"session_closed": True})]
+
+    async def aclose(self) -> None:
+        """No-op; the fake owns no connection pool."""
+
+
+def _args(tmp_path: Path, **overrides: Any) -> argparse.Namespace:
+    """Parse a minimal valid argument set.
+
+    Args:
+        tmp_path: Output directory.
+        **overrides: Attribute overrides applied after parsing.
+
+    Returns:
+        The namespace.
+    """
+    argv = [
+        "--runtime-url",
+        "http://runtime.invalid",
+        "--policy-id",
+        "pi05_aloha_robotwin",
+        "--assets-path",
+        "/workspace/RoboTwin",
+        "--seed",
+        "100100000",
+        "--logical-id",
+        "adjust-bottle-0",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    args = build_parser().parse_args(argv)
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_episode_seed_reaches_the_family_as_a_reset_state_id(tmp_path: Path) -> None:
+    """RoboTwin's seed *is* the scene, so it must be pinned, not merely seeded.
+
+    A paired same-seed gate only reproduces if the scene id is explicit; passing
+    the value as ``seed`` alone would let the family fall back to its own
+    success-seed rotation.
+    """
+    client = _FakeClient()
+    asyncio.run(run(_args(tmp_path), client=client))
+
+    spec = client.reset_specs[0]
+    assert spec.reset_state_id == 100100000
+    assert spec.seed == 100100000
+
+
+def test_chunk_loop_tolerates_a_family_with_no_per_step_records(
+    tmp_path: Path,
+) -> None:
+    """``final_only`` means ``per_step`` is None; the audit says so explicitly."""
+    client = _FakeClient(chunks_until_done=3)
+    record = asyncio.run(run(_args(tmp_path), client=client))
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "chunks.jsonl").read_text().splitlines()
+    ]
+    assert len(rows) == 3
+    assert all(row["per_step_available"] is False for row in rows)
+    assert all(row["evidence_granularity"] == "chunk" for row in rows)
+    assert rows[0]["executed_horizon"] == 25
+    assert rows[0]["discarded_actions"] == 25
+    assert record.artifact_index["chunks_executed"] == 3
+    assert record.artifact_index["steps_executed"] == 75
+
+
+def test_success_is_taken_from_the_family_info(tmp_path: Path) -> None:
+    """Success is the family's authoritative flag, not a reward threshold."""
+    ok = asyncio.run(run(_args(tmp_path / "ok"), client=_FakeClient(succeed=True)))
+    assert ok.success is True
+    assert ok.status == "valid"
+
+    bad = asyncio.run(run(_args(tmp_path / "bad"), client=_FakeClient(succeed=False)))
+    assert bad.success is False
+
+
+def test_record_carries_the_frozen_digests(tmp_path: Path) -> None:
+    """A campaign checks the manifest against exactly these values."""
+    record = asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+    index = record.artifact_index
+    assert index["env_spec_digest"] == ENV_SPEC_DIGEST
+    assert index["tool_catalog_digest"] == DEFAULT_ROBOTWIN_TOOL_CATALOG.digest
+    assert index["tool_binding_digest"] == binding_for_task("adjust_bottle").digest
+    assert index["arm_scoped_tools"] == list(
+        binding_for_task("adjust_bottle").arm_scoped_tool_names
+    )
+    # Recorded on every episode so a chunk-granular diagnosis is never compared
+    # like-for-like with a per-step family's.
+    assert index["evidence_granularity"] == "chunk"
+
+
+def test_env_spec_carries_the_pool_key_fields(tmp_path: Path) -> None:
+    """Every field here enters the pool digest; a mismatch cold-starts SAPIEN."""
+    client = _FakeClient()
+    asyncio.run(run(_args(tmp_path, execute_horizon=25), client=client))
+
+    env_spec = client.created[0].env_spec
+    assert env_spec.env_family == "robotwin"
+    assert env_spec.env_config["task_name"] == "adjust_bottle"
+    assert env_spec.env_config["execute_horizon"] == 25
+    assert env_spec.env_config["collect_wrist_camera"] is True
+    assert env_spec.resource_hints == {"accelerator": True}
+    # The per-episode seed must NOT be in the spec: it would split the pool.
+    assert "seed" not in env_spec.env_config
+
+
+def test_session_is_always_closed(tmp_path: Path) -> None:
+    """Closing is what returns the env slot to the pool for the next rollout."""
+    client = _FakeClient()
+    asyncio.run(run(_args(tmp_path), client=client))
+    assert client.closed is True
+
+
+def test_horizon_cap_stops_a_runaway_episode(tmp_path: Path) -> None:
+    """A family that never terminates must still be bounded by max steps."""
+    client = _FakeClient(chunks_until_done=10_000)
+    record = asyncio.run(run(_args(tmp_path, env_max_steps=100), client=client))
+    # 100 steps at 25 per chunk.
+    assert client.chunk_calls == 4
+    assert record.success is False
+
+
+def test_cli_rejects_a_zero_execute_horizon() -> None:
+    """A zero horizon would submit an empty chunk forever."""
+    args = build_parser().parse_args(
+        [
+            "--runtime-url",
+            "u",
+            "--policy-id",
+            "p",
+            "--assets-path",
+            "a",
+            "--seed",
+            "1",
+            "--logical-id",
+            "l",
+            "--output-dir",
+            "o",
+            "--execute-horizon",
+            "0",
+        ]
+    )
+    assert args.execute_horizon == 0  # parsed; rejected by main()
+
+
+# ------------------------------------------------------- the reviewed path
+
+
+def _rules_file(tmp_path: Path, rules: list[dict]) -> str:
+    """Write a frozen rule list to disk.
+
+    Args:
+        tmp_path: Test directory.
+        rules: The rules.
+
+    Returns:
+        The path as a string.
+    """
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(rules), encoding="utf-8")
+    return str(path)
+
+
+STALL_RULE = {
+    "rule_id": "left-arm-stalled",
+    "title": "Left arm has not moved",
+    "feature": "robotwin.arm.left.stalled_chunks",
+    "operator": "ge",
+    "threshold": 1,
+    "dwell_steps": 1,
+    "cooldown_steps": 0,
+    "proposal": "hold the left arm",
+    "evidence_ids": ["robotwin.arm.left.joint_motion"],
+}
+
+
+def test_without_critic_rules_the_path_stays_pure_vla(tmp_path: Path) -> None:
+    """The baseline must remain one atomic policy_step per chunk."""
+    client = _FakeClient()
+    record = asyncio.run(run(_args(tmp_path), client=client))
+    assert client.infer_calls == 0
+    assert client.action_steps == []
+    assert record.artifact_index["baseline_mode"] == "pure_vla"
+    assert record.artifact_index["critic_rule_count"] == 0
+
+
+def test_critic_rules_switch_to_the_reviewed_path(tmp_path: Path) -> None:
+    """With rules, nothing reaches the simulator before Role1 has ruled."""
+    client = _FakeClient(chunks_until_done=2)
+    record = asyncio.run(
+        run(
+            _args(tmp_path, critic_rules=_rules_file(tmp_path, [STALL_RULE])),
+            client=client,
+        ),
+    )
+    assert client.infer_calls == 2
+    assert len(client.action_steps) == 2
+    assert record.artifact_index["baseline_mode"] == "critic_reviewed"
+    assert record.artifact_index["critic_rule_count"] == 1
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "chunks.jsonl").read_text().splitlines()
+    ]
+    assert all(row["source"] in {"vla", "recovery"} for row in rows)
+
+
+def test_role1_decisions_are_persisted(tmp_path: Path) -> None:
+    """A verdict that never reaches the audit trail cannot be reviewed later."""
+    client = _FakeClient(chunks_until_done=3)
+    asyncio.run(
+        run(
+            _args(tmp_path, critic_rules=_rules_file(tmp_path, [STALL_RULE])),
+            client=client,
+        ),
+    )
+    decisions = tmp_path / "role1_decisions.jsonl"
+    assert decisions.exists()
+    rows = [json.loads(line) for line in decisions.read_text().splitlines()]
+    assert rows, "a firing critic rule must produce a recorded verdict"
+    # The reference Role1 rejects an arm-less proposal, and the stall rule does
+    # not name one -- so the recorded verdict must say exactly that.
+    assert rows[0]["accepted"] is False
+    assert "names no arm" in rows[0]["reason"]
+
+
+def test_record_states_the_dwell_unit(tmp_path: Path) -> None:
+    """``dwell_steps`` counts chunks here and simulator steps elsewhere.
+
+    A reader of the record must not have to infer which one a frozen rule meant.
+    """
+    record = asyncio.run(
+        run(_args(tmp_path, execute_horizon=25), client=_FakeClient()),
+    )
+    semantics = record.artifact_index["dwell_semantics"]
+    assert semantics["dwell_unit"] == "chunk"
+    assert semantics["sim_steps_per_chunk"] == 25
+
+
+# --------------------------------------------------- trajectory artifacts
+
+
+def _rows(path: Path) -> list[dict]:
+    """Read a JSONL artifact.
+
+    Args:
+        path: The file.
+
+    Returns:
+        Its rows.
+    """
+    text = path.read_text()
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def test_all_four_trajectory_artifacts_exist(tmp_path: Path) -> None:
+    """``_strict_jsonl`` reads all four and raises on a missing file.
+
+    A run that records nothing of a given kind must still leave an empty
+    artifact, or indexing fails before it can look at anything.
+    """
+    asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+    for name in ("chunks", "actions", "states", "tools"):
+        assert (tmp_path / f"{name}.jsonl").exists(), f"{name}.jsonl missing"
+
+
+def test_failed_episode_carries_a_failure_segment(tmp_path: Path) -> None:
+    """Without segments the Cluster stage stalls silently rather than failing.
+
+    ``cluster_failure_segments([])`` returns ``[]``, so an episode that reaches
+    the campaign with no segments produces no cluster and no error -- the
+    hardest kind of gap to notice.
+    """
+    record = asyncio.run(
+        run(_args(tmp_path), client=_FakeClient(succeed=False)),
+    )
+    assert record.success is False
+    assert record.failure_segments, "a failed episode must localise something"
+    assert record.failure_segment is not None
+    assert record.artifact_index["failure_segment_count"] == len(
+        record.failure_segments
+    )
+    assert record.artifact_index["trajectory_index"] is not None
+
+
+def test_gen0_failure_falls_back_to_horizon_incomplete(tmp_path: Path) -> None:
+    """The honest current limit: no progress scalar means no causal localisation.
+
+    A pure-VLA RoboTwin failure has no critic reject, no tool error and no Role1
+    contract failure, and ``_window_no_progress`` keys off feature names
+    (``task_progress`` / ``residual_to_success`` / ...) that this family cannot
+    supply without a privileged simulator feature it does not declare. So every
+    such failure lands on ``_fallback_incomplete``.
+
+    That is a real limitation, not a passing detail: it produces one cluster at
+    100% prevalence, which is exactly what ``trajectory._segments`` warns hides
+    the actionable failure modes. This test pins the current behaviour so the
+    day a progress feature is added, it fails and has to be re-read.
+    """
+    record = asyncio.run(
+        run(_args(tmp_path), client=_FakeClient(succeed=False)),
+    )
+    classes = {segment.failure_class for segment in record.failure_segments}
+    assert classes == {"horizon_incomplete"}
+    assert record.failure_segments[0].earliest_divergence_step is None
+
+
+def test_successful_episode_carries_no_segments(tmp_path: Path) -> None:
+    """``EpisodeRecord`` rejects a success that also claims a failure."""
+    record = asyncio.run(run(_args(tmp_path), client=_FakeClient(succeed=True)))
+    assert record.success is True
+    assert record.failure_segments == ()
+    assert record.failure_segment is None
+
+
+def test_action_count_survives_an_empty_actions_artifact(tmp_path: Path) -> None:
+    """The fast path never sees individual actions; the count must still be right.
+
+    ``policy_step`` does inference and execution inside the Runtime in one
+    operation, so ``actions.jsonl`` is empty on the pure-VLA baseline.
+    ``_make_events`` derives the count from the chunk rows' ``executed_horizon``
+    instead.
+    """
+    client = _FakeClient(chunks_until_done=3)
+    record = asyncio.run(run(_args(tmp_path), client=client))
+    assert _rows(tmp_path / "actions.jsonl") == []
+    index = record.artifact_index["trajectory_index"]
+    assert index["action_count"] == 75  # 3 chunks x executed_horizon 25
+
+
+def test_reviewed_path_records_every_executed_action(tmp_path: Path) -> None:
+    """With Role1 in the loop the client owns the chunk, so it can record it."""
+    client = _FakeClient(chunks_until_done=2)
+    asyncio.run(
+        run(
+            _args(tmp_path, critic_rules=_rules_file(tmp_path, [STALL_RULE])),
+            client=client,
+        ),
+    )
+    actions = _rows(tmp_path / "actions.jsonl")
+    assert actions, "the reviewed path must record its actions"
+    assert all(row["action_dim"] == 14 for row in actions)
+    # Step indices are contiguous across chunks, not restarted per chunk.
+    assert [row["step_index"] for row in actions] == list(range(len(actions)))
+
+
+def test_state_rows_are_chunk_final_and_say_so(tmp_path: Path) -> None:
+    """``final_only`` means the state timeline is chunk-granular, not per-step.
+
+    A reader counting rows must not conclude the episode was 3 steps long.
+    """
+    client = _FakeClient(chunks_until_done=3)
+    asyncio.run(run(_args(tmp_path), client=client))
+    states = _rows(tmp_path / "states.jsonl")
+    assert len(states) == 3
+    assert all(row["evidence_granularity"] == "chunk" for row in states)
+    assert [row["step_index"] for row in states] == [25, 50, 75]
+    assert len(states[0]["state"]["joint_positions"]) == 14
+    assert set(states[0]["state"]) == {
+        "joint_positions",
+        "robotwin.state_available",
+        "robotwin.arm.left.gripper",
+        "robotwin.arm.right.gripper",
+    }
+
+
+def test_state_rows_publish_no_fabricated_progress_scalar(tmp_path: Path) -> None:
+    """Joint travel is not task progress, and must not be labelled as it.
+
+    ``_window_no_progress`` keys off these exact names. Publishing proprioception
+    under one of them would make "the robot stopped moving" indistinguishable
+    from "the task stopped progressing" in every downstream diagnosis.
+    """
+    asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+    forbidden = ("task_progress", "progress", "completion")
+    for row in _rows(tmp_path / "states.jsonl"):
+        flat = json.dumps(row)
+        assert not any(f'"{name}"' in flat for name in forbidden)
+        assert "residual_to_success" not in flat
+        assert "distance_to_goal" not in flat
+
+
+def test_tool_events_record_the_action_source(tmp_path: Path) -> None:
+    """The tool timeline is what tells a diagnosis which actor drove a step."""
+    asyncio.run(run(_args(tmp_path), client=_FakeClient(chunks_until_done=2)))
+    tools = _rows(tmp_path / "tools.jsonl")
+    assert len(tools) == 2
+    assert all(row["source"] == "vla" for row in tools)
+    assert all(row["environment_write"] is True for row in tools)
+
+
+# ------------------------------------------------- per-step frame capture
+
+
+def test_capture_switches_the_baseline_off_the_atomic_path(tmp_path: Path) -> None:
+    """Capturing requires seeing every step, which ``policy_step`` cannot give.
+
+    The atomic operation does inference and execution inside the Runtime, so
+    there is no per-step boundary to observe at. Capturing therefore splits it
+    into ``policy_infer`` + one ``action_step`` per action -- which Experiment A
+    established is physically identical.
+    """
+    plain = _FakeClient(chunks_until_done=2)
+    asyncio.run(run(_args(tmp_path / "plain"), client=plain))
+    assert plain.infer_calls == 0
+    assert plain.action_steps == []
+
+    captured = _FakeClient(chunks_until_done=1_000, with_images=True)
+    asyncio.run(
+        run(
+            _args(tmp_path / "cap", capture_frames=True, env_max_steps=4),
+            client=captured,
+        ),
+    )
+    assert captured.infer_calls > 0
+    # One action_step per action, not per chunk.
+    assert len(captured.action_steps) == 4
+
+
+def test_captured_states_are_per_step_not_per_chunk(tmp_path: Path) -> None:
+    """The evidence machinery's windows are counted in rows, so rows must be steps.
+
+    ``index_episode_trajectory`` defaults ``context_before``/``context_after``/
+    ``no_progress_window`` to 8 rows; at chunk granularity that spans a whole
+    episode and localisation degenerates.
+    """
+    client = _FakeClient(chunks_until_done=1_000, with_images=True)
+    asyncio.run(
+        run(
+            _args(tmp_path, capture_frames=True, env_max_steps=6),
+            client=client,
+        ),
+    )
+    states = _rows(tmp_path / "states.jsonl")
+    assert len(states) == 6
+    assert [row["step_index"] for row in states] == [1, 2, 3, 4, 5, 6]
+
+
+def test_chunk_row_reports_the_whole_block_not_the_last_sub_step(
+    tmp_path: Path,
+) -> None:
+    """``_make_events`` derives ``action_count`` from this field.
+
+    Stepwise submission makes the final sub-step report ``executed_horizon=1``;
+    recording that as the chunk's horizon would undercount the episode by the
+    block length.
+    """
+    client = _FakeClient(chunks_until_done=1_000, with_images=True)
+    record = asyncio.run(
+        run(
+            _args(tmp_path, capture_frames=True, env_max_steps=4, execute_horizon=2),
+            client=client,
+        ),
+    )
+    chunks = _rows(tmp_path / "chunks.jsonl")
+    assert [row["executed_horizon"] for row in chunks] == [2, 2]
+    assert record.artifact_index["trajectory_index"]["action_count"] == 4
+
+
+def test_videos_are_encoded_from_the_observation_frames(tmp_path: Path) -> None:
+    """RoboTwin records nothing, so the only frames are the ones the policy saw."""
+    pytest.importorskip("imageio")
+    client = _FakeClient(chunks_until_done=1_000, with_images=True)
+    record = asyncio.run(
+        run(
+            _args(tmp_path, capture_frames=True, env_max_steps=6),
+            client=client,
+        ),
+    )
+    videos = record.artifact_index["videos"]
+    assert set(videos) == {"head", "left_wrist", "right_wrist"}
+    for path in videos.values():
+        assert Path(path).is_file()
+        assert Path(path).stat().st_size > 0
+
+
+def test_visual_evidence_is_built_when_three_cameras_were_recorded(
+    tmp_path: Path,
+) -> None:
+    """Stage 1 refuses a diagnosis with fewer than three evidence items."""
+    pytest.importorskip("imageio")
+    client = _FakeClient(chunks_until_done=1_000, with_images=True, succeed=False)
+    record = asyncio.run(
+        run(
+            _args(tmp_path, capture_frames=True, env_max_steps=12),
+            client=client,
+        ),
+    )
+    evidence = record.artifact_index["visual_evidence"]
+    assert evidence is not None
+    assert evidence.get("available") is not False, evidence.get("reason")
+
+
+def test_missing_cameras_degrade_instead_of_failing_the_episode(
+    tmp_path: Path,
+) -> None:
+    """Losing evidence must not turn a valid episode into an infra failure.
+
+    The record still has to say *why* it cannot be diagnosed, or the gap only
+    surfaces much later inside Stage 1.
+    """
+    client = _FakeClient(chunks_until_done=1_000, with_images=False)
+    record = asyncio.run(
+        run(
+            _args(tmp_path, capture_frames=True, env_max_steps=4),
+            client=client,
+        ),
+    )
+    assert record.status == "valid"
+    evidence = record.artifact_index["visual_evidence"]
+    assert evidence["available"] is False
+    assert "two synchronized cameras" in evidence["reason"]
+
+
+def test_no_capture_reports_why_there_is_no_evidence(tmp_path: Path) -> None:
+    """A throughput baseline is still a valid episode, just not a diagnosable one."""
+    record = asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+    evidence = record.artifact_index["visual_evidence"]
+    assert evidence["available"] is False
+    assert "--capture-frames" in evidence["reason"]
+
+
+def test_the_campaign_none_sentinel_is_not_a_digest(tmp_path: Path) -> None:
+    """``campaign.py`` substitutes ``{bundle_sha256}`` with ``"none"`` in Gen0.
+
+    Passing it straight through makes ``EpisodeRecord`` reject the episode as
+    malformed, which the campaign then counts as ``infra_invalid`` -- so every
+    Gen0 rollout fails and the campaign blocks on infrastructure. Observed on a
+    real campaign run before this was fixed.
+    """
+    record = asyncio.run(
+        run(_args(tmp_path, bundle_sha256="none"), client=_FakeClient()),
+    )
+    assert record.bundle_sha256 is None
+
+    digest = "a" * 64
+    kept = asyncio.run(
+        run(
+            _args(tmp_path / "kept", bundle_sha256=digest),
+            client=_FakeClient(),
+        ),
+    )
+    assert kept.bundle_sha256 == digest
+
+
+# --- paired-gate reset identity ---------------------------------------------
+#
+# Observed on a real campaign: with this absent, Diagnose and Stage2 both
+# completed and the run then died at the same-seed gate with
+# "gate parent source lacks reset observation identity"
+# (gate_runner._source_parent_for_pair), after the rollout budget was spent.
+
+
+def test_record_carries_the_reset_observation_identity(tmp_path: Path) -> None:
+    """A same-seed gate refuses a parent that cannot prove its reset."""
+    record = asyncio.run(
+        run(_args(tmp_path), client=_FakeClient(with_images=True))
+    )
+
+    identity = record.artifact_index["initial_observation_identity"]
+    # gating._same_physical_reset raises unless the state digest is a non-empty
+    # string; camera digests are audited for drift but never decide the match.
+    assert isinstance(identity["state_sha256"], str)
+    assert identity["state_sha256"]
+    assert set(identity["camera_sha256"]) == {"head", "left_wrist", "right_wrist"}
+
+
+def test_reset_identity_does_not_depend_on_cameras(tmp_path: Path) -> None:
+    """The binding is the physical state; cameras are evidence, not identity.
+
+    A reset observation that carries no frames must still produce a usable
+    identity, because ``_same_physical_reset`` decides on ``state_sha256``
+    alone and only counts camera drift.
+    """
+    record = asyncio.run(
+        run(_args(tmp_path), client=_FakeClient(with_images=False))
+    )
+
+    identity = record.artifact_index["initial_observation_identity"]
+    assert identity["state_sha256"]
+    assert identity["camera_sha256"] == {}
+
+
+def test_reset_identity_is_stable_for_the_same_seed(tmp_path: Path) -> None:
+    """The seed is the scene, so two rollouts of it must bind identically."""
+    first = asyncio.run(run(_args(tmp_path / "a"), client=_FakeClient()))
+    second = asyncio.run(run(_args(tmp_path / "b"), client=_FakeClient()))
+
+    assert (
+        first.artifact_index["initial_observation_identity"]["state_sha256"]
+        == second.artifact_index["initial_observation_identity"]["state_sha256"]
+    )
+
+
+# --- frozen candidate bundle -------------------------------------------------
+
+
+def _bundle_payload() -> dict[str, Any]:
+    """A minimal bundle whose single critic rule enables the reviewed path."""
+    return {
+        "candidate_id": "candidate-1",
+        "generation": 1,
+        "parent_sha256": None,
+        "diagnosis_sha256": "0" * 64,
+        "causal_hypothesis": "the gripper never closes at contact",
+        "mechanism_change": "close the active gripper once contact is confirmed",
+        "validation_plan": "paired same-seed trial",
+        "critic_rules": [
+            {
+                "rule_id": "gripper-open",
+                "title": "gripper stays open at contact",
+                # A real feature name: extract_robotwin_critic_features mirrors
+                # the plane per arm under "robotwin.arm.<arm>.".
+                "feature": "robotwin.arm.left.gripper",
+                "operator": "gt",
+                "threshold": 0.9,
+                "dwell_steps": 1,
+                "cooldown_steps": 0,
+                "proposal": "close the left gripper",
+                "evidence_ids": ["artifact-1"],
+            }
+        ],
+        # CandidateBundle.__post_init__ rejects a critic rule with no
+        # executable recovery, so the pair is the smallest legal bundle.
+        "recovery_rules": [
+            {
+                "recovery_id": "close-gripper",
+                "title": "close the active gripper",
+                "trigger_rule_ids": ["gripper-open"],
+                "precondition": "contact is confirmed",
+                "steps": [
+                    {
+                        "tool": "robotwin.gripper.set",
+                        "parameters": {"arm": "left", "opening": 0.0},
+                        "stop_when": "the gripper reports closed",
+                    }
+                ],
+                "safety_constraints": ["never move the idle arm"],
+                "stop_condition": "the bottle is retained",
+                "fallback": "hold both arms",
+                "evidence_ids": ["artifact-1"],
+            }
+        ],
+    }
+
+
+def test_bundle_supplies_the_rules_for_a_gate_arm(tmp_path: Path) -> None:
+    """A gate arm is pinned to the frozen bundle, not to loose rule files."""
+    from zetta.evolution.models import CandidateBundle
+
+    # The campaign writes CandidateBundle.as_dict() and digests that, not the
+    # raw authored JSON; the two differ by the model's defaults.
+    bundle = CandidateBundle.from_dict(_bundle_payload())
+    path = tmp_path / "bundle.json"
+    path.write_text(json.dumps(bundle.as_dict()))
+    args = _args(tmp_path / "run")
+    args.bundle = str(path)
+    args.bundle_sha256 = bundle.sha256
+
+    record = asyncio.run(run(args, client=_FakeClient()))
+
+    assert record.artifact_index["critic_rule_count"] == 1
+    assert record.artifact_index["baseline_mode"] == "critic_reviewed"
+
+
+def test_bundle_digest_is_verified(tmp_path: Path) -> None:
+    """A bundle that is not the one the campaign froze must not run."""
+    path = tmp_path / "bundle.json"
+    path.write_text(json.dumps(_bundle_payload()))
+    args = _args(tmp_path / "run")
+    args.bundle = str(path)
+    args.bundle_sha256 = "1" * 64
+
+    with pytest.raises(ValueError, match="does not match --bundle-sha256"):
+        asyncio.run(run(args, client=_FakeClient()))
+
+
+def test_bundle_and_loose_rule_files_are_mutually_exclusive(tmp_path: Path) -> None:
+    """Two rule provenances would make the gate's frozen behaviour ambiguous."""
+    path = tmp_path / "bundle.json"
+    path.write_text(json.dumps(_bundle_payload()))
+    rules = tmp_path / "rules.json"
+    rules.write_text("[]")
+    args = _args(tmp_path / "run")
+    args.bundle = str(path)
+    args.critic_rules = str(rules)
+
+    with pytest.raises(ValueError, match="exclusive"):
+        asyncio.run(run(args, client=_FakeClient()))
+
+
+# --- published vocabulary vs the evaluated plane -----------------------------
+#
+# Observed on a real campaign: states.jsonl published a nested
+# {"left": {"gripper": ...}}, lifecycle._observed_critic_features flattened it
+# to "left.gripper", Stage2 bound that name, and every same-seed gate rollout
+# then died with "critic feature is unavailable: left.gripper" -- the Critic
+# evaluates "robotwin.arm.left.gripper".  Two names for one quantity.
+
+
+def test_published_vocabulary_is_resolvable_by_the_runtime_critic(
+    tmp_path: Path,
+) -> None:
+    """Every name Stage2 can bind must be one the Critic can evaluate."""
+    from robots.robotwin.critic_runtime import extract_robotwin_critic_features
+    from zetta.evolution.lifecycle import _scalar_feature_names
+
+    asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+    rows = _rows(tmp_path / "states.jsonl")
+
+    published: set[str] = set()
+    for row in rows:
+        published.update(_scalar_feature_names(row["state"]))
+    assert published, "states.jsonl offered Stage2 no feature at all"
+
+    evaluable = set(
+        extract_robotwin_critic_features(
+            {"state": rows[0]["state"]["joint_positions"]},
+            chunk_index=0,
+            executed_horizon=25,
+            reward=0.0,
+            terminated=False,
+            truncated=False,
+        )
+    )
+    assert published <= evaluable, sorted(published - evaluable)
+
+
+def test_record_attests_whether_the_learned_path_intervened(tmp_path: Path) -> None:
+    """Without this the same-seed gate can never pass, and says so wrongly.
+
+    ``gating._candidate_intervened`` falls back to a ``"role1:"`` key prefix that
+    this family does not use, so an absent attestation reads as "no
+    intervention"; ``mechanism_diverged`` is then always False and the gate
+    rejects with "candidate never changed the failed parent action trajectory".
+    """
+    record = asyncio.run(run(_args(tmp_path), client=_FakeClient()))
+
+    # A pure-VLA Gen0 episode genuinely did not intervene.
+    assert record.artifact_index["candidate_intervention"] is False
+    # The key must exist rather than be inferred, which is what the fallback
+    # would otherwise do from a key this family never writes.
+    assert not any(
+        str(key).startswith("role1:") for key in record.artifact_index
+    )

--- a/tests/test_evolution_lifecycle.py
+++ b/tests/test_evolution_lifecycle.py
@@ -14,6 +14,7 @@ from zetta.evolution.lifecycle import (
     _authoritative_task_contract,
     _latest_stage2_context,
     _materialize_multimodal_cluster_review,
+    _normalized_stage1_output,
     _observed_critic_features,
     _route_inconclusive_diagnosis,
     authorize_provisional_hypothesis,
@@ -1008,3 +1009,69 @@ def test_five_failed_candidates_switch_to_secondary_then_stop(tmp_path: Path) ->
         store.state()["optimization_outcome"]
         == "no_candidate_passed_primary_or_secondary"
     )
+
+
+# --- Stage1 output vs accepted diagnosis -----------------------------------
+#
+# Observed on a real campaign: the planner emitted "task_contract": {} -- the
+# field's own default -- every other field matched byte for byte, and
+# CausalDiagnosis.as_dict() drops the key when it is falsy.  The raw-vs-
+# normalised digest comparison in _active_stage1_context therefore mismatched
+# and stalled the run at PROPOSE with the diagnosis already accepted.
+
+
+def _stage1_diagnosis() -> CausalDiagnosis:
+    return CausalDiagnosis(
+        diagnosis_id="diagnosis-normalise",
+        cluster_id="cluster-001",
+        outcome="the horizon elapsed with the bottle still table-supported",
+        immediate_trigger="the active gripper stayed open through truncation",
+        root_cause="the policy never closed the gripper at contact",
+        contributing_causes=("contact occurred late in the horizon",),
+        competing_hypotheses=(
+            "the policy never closed the gripper at contact",
+            "the gripper was commanded shut but did not actuate",
+        ),
+        owner_layer="vla",
+        affected_component="grasp-phase gripper-action generation",
+        earliest_divergence="around step 30",
+        supporting_evidence_ids=("artifact-1",),
+        counterevidence_ids=(),
+        falsifier="a realised close still yields no retention",
+        distinguishing_check="override only the gripper channel at contact",
+        required_validation="paired same-seed live trial",
+        confidence=0.88,
+    )
+
+
+def test_normalized_stage1_output_tolerates_spelled_out_defaults() -> None:
+    diagnosis = _stage1_diagnosis()
+    accepted = diagnosis.as_dict()
+    assert "task_contract" not in accepted
+    assert "visual_evidence" not in accepted
+
+    raw = dict(accepted)
+    raw["task_contract"] = {}
+    raw["visual_evidence"] = []
+
+    assert canonical_sha256(_normalized_stage1_output(raw)) == canonical_sha256(
+        accepted
+    )
+
+
+def test_normalized_stage1_output_still_detects_a_semantic_difference() -> None:
+    accepted = _stage1_diagnosis().as_dict()
+    raw = dict(accepted)
+    raw["root_cause"] = "the gripper was commanded shut but did not actuate"
+
+    assert canonical_sha256(_normalized_stage1_output(raw)) != canonical_sha256(
+        accepted
+    )
+
+
+def test_normalized_stage1_output_reports_an_unusable_output_as_a_mismatch() -> None:
+    raw = dict(_stage1_diagnosis().as_dict())
+    raw["unexpected_field"] = "not a diagnosis field"
+
+    with pytest.raises(ValueError, match="differs from accepted diagnosis"):
+        _normalized_stage1_output(raw)

--- a/tests/test_prepare_robotwin_campaign.py
+++ b/tests/test_prepare_robotwin_campaign.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The RoboTwin campaign preparer.
+
+Most of what a preparer does is shared across environments; what is worth
+pinning here is the one thing RoboTwin had to change and the reasons it had to
+be recorded.
+
+RoboTwin selects its scene from the seed outright, and only its curated
+``success_seeds`` are known to be solvable, so the campaign draws from that list
+rather than from a dense integer range. The protocol's shape is unchanged -- a
+fixed, disjoint, pre-committed held-out block -- but the values are no longer
+the literal ``1..20``, so the provenance has to be in the artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "evolution"))
+
+from prepare_robotwin_campaign import (  # noqa: E402
+    build_parser,
+    load_success_seeds,
+    prepare,
+)
+
+COMMIT = "a" * 40
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _seeds_file(
+    tmp_path: Path,
+    count: int = 120,
+    task: str = "adjust_bottle",
+    name: str = "eval_seeds.json",
+) -> Path:
+    """Write a curated success-seed file in RLinf's shape.
+
+    Args:
+        tmp_path: Test directory.
+        count: How many seeds to publish.
+        task: The task name.
+        name: File name, so a test can hold two different populations at once.
+
+    Returns:
+        The file path.
+    """
+    payload = {
+        task: {
+            "task_name": task,
+            "success_seeds": [100100000 + index for index in range(count)],
+        }
+    }
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
+    """Build a valid argument set.
+
+    Args:
+        tmp_path: Test directory.
+        **overrides: Attribute overrides.
+
+    Returns:
+        The namespace.
+    """
+    args = build_parser().parse_args(
+        [
+            "--output-root",
+            str(tmp_path / "g0000"),
+            "--campaign-id",
+            "robotwin-adjust-bottle-g0000",
+            "--repository-root",
+            str(REPO_ROOT),
+            "--runtime-python",
+            sys.executable,
+            "--code-commit",
+            COMMIT,
+            "--seeds-path",
+            str(_seeds_file(tmp_path)),
+            "--assets-path",
+            "/path/to/RoboTwin",
+            "--policy-id",
+            "pi05_aloha_robotwin",
+            "--master-seed",
+            "2026090201",
+            "--runtime-url",
+            "http://127.0.0.1:18730",
+        ]
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+# ------------------------------------------------------------- seed source
+
+
+def test_success_seeds_are_read_per_task(tmp_path: Path) -> None:
+    """The population is the task's own solvable set, not a shared one."""
+    seeds = load_success_seeds(_seeds_file(tmp_path), "adjust_bottle")
+    assert len(seeds) == 120
+    assert seeds[0] == 100100000
+
+
+def test_an_unknown_task_fails_closed(tmp_path: Path) -> None:
+    """Silently falling back to a dense range would break the held-out gate."""
+    with pytest.raises(ValueError, match="no entry for RoboTwin task"):
+        load_success_seeds(_seeds_file(tmp_path), "lift_pot")
+
+
+def test_duplicate_seeds_are_collapsed(tmp_path: Path) -> None:
+    """A duplicated seed would make the held-out block smaller than declared."""
+    path = tmp_path / "dup.json"
+    path.write_text(json.dumps({"t": {"success_seeds": [7, 7, 8]}}), encoding="utf-8")
+    assert load_success_seeds(path, "t") == (7, 8)
+
+
+# ------------------------------------------------------------- preparation
+
+
+def test_heldout_block_comes_from_the_curated_list(tmp_path: Path) -> None:
+    """The literal 1..20 is not usable here; the substitution must be exact."""
+    prereg = prepare(_args(tmp_path))
+    assert len(prereg["heldout_seeds"]) == 20
+    assert list(prereg["heldout_seeds"]) == [100100000 + i for i in range(20)]
+    # The protocol's shape survives: disjoint, and the dev block is the
+    # requested size.
+    assert len(prereg["rollout_seeds"]) == 50
+    assert not set(prereg["heldout_seeds"]) & set(prereg["rollout_seeds"])
+
+
+def test_seed_provenance_is_recorded_in_both_artifacts(tmp_path: Path) -> None:
+    """A reviewer must see why the seeds are not 1..20 without reading code."""
+    args = _args(tmp_path)
+    prereg = prepare(args)
+    provenance = prereg["seed_provenance"]
+    assert provenance["population_kind"] == "robotwin_curated_success_seeds"
+    assert provenance["population_size"] == 120
+    assert len(provenance["source_file_sha256"]) == 64
+    assert "not a gate" in provenance["rationale"]
+
+    manifest = json.loads((Path(args.output_root) / "manifest.json").read_text())
+    assert manifest["runtime"]["seed_provenance"] == provenance
+
+
+def test_manifest_records_the_chunk_evidence_unit(tmp_path: Path) -> None:
+    """A chunk-granular diagnosis must not be compared with a per-step one."""
+    args = _args(tmp_path, execute_horizon=25)
+    prereg = prepare(args)
+    assert prereg["evidence_granularity"] == "chunk"
+    manifest = json.loads((Path(args.output_root) / "manifest.json").read_text())
+    assert manifest["runtime"]["evidence_granularity"] == "chunk"
+    assert manifest["runtime"]["dwell_semantics"]["sim_steps_per_chunk"] == 25
+
+
+def test_frozen_command_carries_no_bearer_token(tmp_path: Path) -> None:
+    """The command lands in the manifest; a token there would be a leak."""
+    args = _args(tmp_path)
+    prepare(args)
+    manifest = json.loads((Path(args.output_root) / "manifest.json").read_text())
+    command = manifest["runtime"]["rollout_command"]
+    assert "--runtime-token" not in command
+    # The queue substitutes these; a preparer that resolved them early would
+    # freeze one episode's identity into every episode.
+    assert "{seed}" in command
+    assert "{result_file}" in command
+    # The Gateway owns env-slot arbitration under the Runtime, so the campaign
+    # passes the shared endpoint directly instead of leasing a slot.
+    assert "{env_endpoint}" not in command
+    assert "http://127.0.0.1:18730" in command
+    # Without frame capture the episodes cannot reach Stage 1 at all.
+    assert "--capture-frames" in command
+
+
+def test_catalog_artifact_surfaces_the_arm_requirement(tmp_path: Path) -> None:
+    """The arm-scoped set is the expensive-to-change part of the catalog."""
+    args = _args(tmp_path)
+    prepare(args)
+    catalog = json.loads((Path(args.output_root) / "tool-catalog.json").read_text())
+    assert catalog["arm_scoped_tools"], "a bimanual binding must scope some tools"
+    assert catalog["task"] == "adjust_bottle"
+    assert len(catalog["digest"]) == 64
+
+
+def test_role1_contract_states_the_bimanual_rules(tmp_path: Path) -> None:
+    """The prompt contract is hashed into the preregistration, so pin it."""
+    args = _args(tmp_path)
+    prereg = prepare(args)
+    contract = json.loads(
+        (Path(args.output_root) / "prompt-contract.json").read_text()
+    )["role1"]
+    assert "names no arm" in contract
+    assert "zero vector" in contract
+    assert "chunk-granular" in contract
+    assert len(prereg["prompt_sha256"]) == 64
+
+
+def test_too_few_curated_seeds_fails_closed(tmp_path: Path) -> None:
+    """A short list must not silently yield a smaller held-out block."""
+    short = _seeds_file(tmp_path, count=10, name="short_seeds.json")
+    args = _args(tmp_path, seeds_path=str(short))
+    with pytest.raises(ValueError, match="curated success"):
+        prepare(args)
+
+
+def test_nonzero_generation_requires_a_parent(tmp_path: Path) -> None:
+    """A generation with no parent bundle has nothing to have evolved from."""
+    with pytest.raises(ValueError, match="requires --parent-bundle"):
+        prepare(_args(tmp_path, generation=1))
+
+
+def test_output_root_is_never_reused(tmp_path: Path) -> None:
+    """A campaign root is immutable; writing into an existing one would edit it."""
+    args = _args(tmp_path)
+    prepare(args)
+    with pytest.raises(FileExistsError):
+        prepare(_args(tmp_path))
+
+
+def test_frozen_interpreter_keeps_the_venv(tmp_path: Path) -> None:
+    """A venv is only active when invoked through its own ``bin/python``.
+
+    That path is a symlink to the base interpreter, so resolving it freezes the
+    base interpreter into the manifest and every rollout dies at ``import
+    numpy`` with the venv's site-packages nowhere on the path. Observed on a
+    real campaign run before this was fixed.
+    """
+    real = tmp_path / "base" / "bin"
+    real.mkdir(parents=True)
+    interpreter = real / "python3.11"
+    interpreter.write_text("#!/bin/sh\n")
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    link = venv_bin / "python"
+    link.symlink_to(interpreter)
+
+    args = _args(tmp_path, runtime_python=str(link))
+    prepare(args)
+    command = json.loads((Path(args.output_root) / "manifest.json").read_text())[
+        "runtime"
+    ]["rollout_command"]
+    assert command[0] == str(link)
+    assert "base/bin" not in command[0]
+
+
+# --- paired-gate command contract -------------------------------------------
+#
+# Observed on a real campaign: Gen0 rollouts, Cluster, Diagnose and Stage2 all
+# completed, and the run then died entering the same-seed gate with
+# "gate rollout command omits frozen fields: ['bundle_file']".  campaign.py only
+# enforces the placeholder from Gen1 on, so nothing catches it earlier.
+
+
+def test_frozen_command_satisfies_the_paired_gate_contract(tmp_path: Path) -> None:
+    """Every field gate_runner._command_template requires must be present."""
+    args = _args(tmp_path)
+    prepare(args)
+    manifest = json.loads((Path(args.output_root) / "manifest.json").read_text())
+    joined = "\n".join(manifest["runtime"]["rollout_command"])
+
+    for field in (
+        "seed",
+        "policy_rng",
+        "logical_id",
+        "attempt_index",
+        "bundle_sha256",
+        "output_dir",
+        "result_file",
+    ):
+        assert f"{{{field}}}" in joined, field
+    # The gate accepts either spelling; the campaign substitutes both names.
+    assert "{bundle_file}" in joined or "{bundle}" in joined

--- a/tests/test_robotwin_action_contract.py
+++ b/tests/test_robotwin_action_contract.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The RoboTwin bimanual action contract.
+
+Two invariants carry most of the weight here, and both are things a single-arm
+robot never has to think about:
+
+1. **Every command names an arm.** There is no default hand.
+2. **"Hold" is not zero.** RoboTwin consumes absolute joint targets, so the arm
+   you are not commanding must be filled from its measured state; a zero vector
+   commands every joint to angle 0 and throws the arm across the table.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robots.robotwin.action_contract import (
+    ACTION_DIM,
+    ARM_SLICES,
+    ARMS,
+    GRIPPER_OFFSET,
+    JOINTS_PER_ARM,
+    ArmSelectionError,
+    RoboTwinAction,
+    action_from_flat,
+    compose_action,
+    hold_action,
+    normalize_arm,
+)
+
+
+def _state() -> np.ndarray:
+    """Build a distinguishable 14-dim joint state.
+
+    Returns:
+        Left half filled with 0.1, right half with -0.2, grippers at 0.5.
+    """
+    state = np.zeros(ACTION_DIM, dtype=np.float64)
+    state[ARM_SLICES["left"]] = 0.1
+    state[ARM_SLICES["right"]] = -0.2
+    state[ARM_SLICES["left"]][GRIPPER_OFFSET] = 0.5
+    state[GRIPPER_OFFSET] = 0.5
+    state[7 + GRIPPER_OFFSET] = 0.5
+    return state
+
+
+def _half(joint: float, gripper: float = 0.5) -> list[float]:
+    """Build one arm's 7-slot command.
+
+    Args:
+        joint: Value for every joint.
+        gripper: Gripper opening.
+
+    Returns:
+        A 7-element command.
+    """
+    return [joint] * JOINTS_PER_ARM + [gripper]
+
+
+def test_layout_is_declared_once() -> None:
+    """The slices are the single source of truth for the bimanual layout."""
+    assert ACTION_DIM == 14
+    assert ARMS == ("left", "right")
+    assert ARM_SLICES["left"] == slice(0, 7)
+    assert ARM_SLICES["right"] == slice(7, 14)
+    covered = list(range(ACTION_DIM))
+    assert covered[ARM_SLICES["left"]] + covered[ARM_SLICES["right"]] == covered
+
+
+def test_an_unnamed_arm_is_an_error_not_a_default() -> None:
+    """On a two-armed robot, an unnamed arm is a bug."""
+    for bad in ("", None):
+        with pytest.raises(ArmSelectionError):
+            normalize_arm(bad)  # type: ignore[arg-type]
+    with pytest.raises(ArmSelectionError, match="unknown arm"):
+        normalize_arm("port")
+    assert normalize_arm("LEFT") == "left"
+    assert normalize_arm(" Both ") == "both"
+
+
+def test_hold_action_repeats_the_measured_state_rather_than_zeroing() -> None:
+    """The identity command for an absolute-target robot is the current state."""
+    state = _state()
+    action = hold_action(state)
+    assert np.allclose(action.as_array(), state.astype(np.float32))
+    assert action.commanded == ARMS
+    assert not np.allclose(action.as_array(), np.zeros(ACTION_DIM))
+
+
+def test_single_arm_command_holds_the_other_arm_at_its_measured_pose() -> None:
+    """This is the trap the contract exists to close.
+
+    Commanding only the left arm must leave the right arm exactly where it was,
+    not at joint angle zero.
+    """
+    state = _state()
+    action = compose_action(state, left=_half(0.9, gripper=0.0))
+
+    assert action.commanded == ("left",)
+    assert action.arm_half("left") == tuple(_half(0.9, gripper=0.0))
+    # The uncommanded arm is a copy of the measurement, not zeros.
+    assert action.arm_half("right") == tuple(state[ARM_SLICES["right"]])
+    assert action.arm_half("right") != tuple([0.0] * (JOINTS_PER_ARM + 1))
+
+
+def test_both_arms_can_be_commanded_together() -> None:
+    """A genuinely bimanual command records both arms."""
+    action = compose_action(_state(), left=_half(0.3), right=_half(-0.4, gripper=1.0))
+    assert action.commanded == ("left", "right")
+    assert action.arm_half("right")[GRIPPER_OFFSET] == pytest.approx(1.0)
+
+
+def test_compose_requires_at_least_one_arm() -> None:
+    """A no-op composition is a mistake; holding both must be explicit."""
+    with pytest.raises(ArmSelectionError, match="at least one arm"):
+        compose_action(_state())
+
+
+def test_compose_requires_the_measured_state() -> None:
+    """The state is mandatory precisely so the idle arm cannot be guessed."""
+    with pytest.raises(ValueError, match="14 values"):
+        compose_action(np.zeros(7), left=_half(0.1))
+
+
+def test_malformed_arm_halves_are_rejected() -> None:
+    """Width, finiteness, joint range and gripper range are all checked."""
+    state = _state()
+    with pytest.raises(ValueError, match="7 values"):
+        compose_action(state, left=[0.1] * 6)
+    with pytest.raises(ValueError, match="non-finite"):
+        compose_action(state, left=_half(float("nan")))
+    with pytest.raises(ValueError, match="rad"):
+        compose_action(state, left=_half(100.0))
+    with pytest.raises(ValueError, match="gripper"):
+        compose_action(state, left=_half(0.1, gripper=3.0))
+
+
+def test_flat_actions_record_which_arms_they_claim() -> None:
+    """The VLA path emits the whole vector; intent is still recorded."""
+    flat = np.linspace(-0.5, 0.5, ACTION_DIM)
+    assert action_from_flat(flat).commanded == ARMS
+    assert action_from_flat(flat, arm="left").commanded == ("left",)
+    with pytest.raises(ValueError, match="14 values"):
+        action_from_flat(np.zeros(7))
+
+
+def test_action_serializes_with_its_arm_provenance() -> None:
+    """An audit record must show which arms a command owned."""
+    payload = compose_action(_state(), right=_half(0.2)).public_dict()
+    assert payload["contract"] == "robotwin_bimanual_joint_v1"
+    assert payload["commanded_arms"] == ["right"]
+    assert len(payload["values"]) == ACTION_DIM
+
+
+def test_arm_half_rejects_both() -> None:
+    """``both`` is a command selector, not an addressable half."""
+    with pytest.raises(ArmSelectionError, match="single arm"):
+        hold_action(_state()).arm_half("both")
+
+
+def test_action_must_command_something() -> None:
+    """A constructed action with no commanded arm is malformed."""
+    with pytest.raises(ArmSelectionError):
+        RoboTwinAction(values=tuple([0.0] * ACTION_DIM), commanded=())

--- a/tests/test_robotwin_critic_runtime.py
+++ b/tests/test_robotwin_critic_runtime.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The RoboTwin Critic feature plane.
+
+Two properties matter more than the individual numbers.
+
+**Every motion feature is per-arm.** A single scalar cannot say which hand
+stalled, and a recovery that does not name an arm cannot be executed, so the
+plane must let a rule address one hand.
+
+**The dwell unit is a chunk, not a simulator step.** RoboTwin is ``final_only``,
+so a rule's ``dwell_steps`` counts chunk boundaries here while it counts
+simulator steps on LIBERO. That factor-of-horizon difference is invisible in the
+rule itself, which is why the plane publishes the conversion.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robots.robotwin.action_contract import ACTION_DIM, ARM_SLICES, GRIPPER_OFFSET
+from robots.robotwin.critic_runtime import (
+    ACTIVE_ARM_FEATURE,
+    GRANULARITY_FEATURE,
+    MOTION_EPSILON,
+    SIM_STEPS_PER_CHUNK_FEATURE,
+    arm_from_proposal,
+    critic_rules_from_payload,
+    describe_dwell_semantics,
+    extract_robotwin_critic_features,
+    next_stall_counts,
+)
+from zetta.evolution.critic import TemporalCritic
+
+
+def _state(left: float = 0.0, right: float = 0.0, grip: float = 0.5) -> list[float]:
+    """Build a 14-dim joint state with per-arm joint values.
+
+    Args:
+        left: Value for every left joint.
+        right: Value for every right joint.
+        grip: Gripper opening for both arms.
+
+    Returns:
+        The state vector.
+    """
+    state = np.zeros(ACTION_DIM, dtype=np.float64)
+    state[ARM_SLICES["left"]] = left
+    state[ARM_SLICES["right"]] = right
+    state[GRIPPER_OFFSET] = grip
+    state[7 + GRIPPER_OFFSET] = grip
+    return list(state)
+
+
+def _features(current, previous=None, *, stalls=None, chunk_index=1, horizon=25):
+    """Extract features with the common arguments filled in.
+
+    Args:
+        current: The chunk-final state.
+        previous: The previous chunk-final state.
+        stalls: Running stall counters.
+        chunk_index: Chunk index.
+        horizon: Executed horizon.
+
+    Returns:
+        The feature dict.
+    """
+    return extract_robotwin_critic_features(
+        {"state": current},
+        chunk_index=chunk_index,
+        executed_horizon=horizon,
+        reward=0.0,
+        terminated=False,
+        truncated=False,
+        previous_state=previous,
+        stall_counts=stalls,
+    )
+
+
+def test_evidence_granularity_is_declared_in_the_plane() -> None:
+    """A rule can refuse to fire on the wrong evidence unit."""
+    features = _features(_state())
+    assert features[GRANULARITY_FEATURE] == "chunk"
+    assert features[SIM_STEPS_PER_CHUNK_FEATURE] == 25
+
+
+def test_dwell_semantics_note_states_the_conversion() -> None:
+    """The note belongs in the manifest next to the frozen rules."""
+    note = describe_dwell_semantics(execute_horizon=25)
+    assert note["dwell_unit"] == "chunk"
+    assert note["sim_steps_per_chunk"] == 25
+    assert "25x" in note["note"]
+
+
+def test_motion_is_reported_per_arm() -> None:
+    """Only the arm that moved reports motion."""
+    features = _features(_state(left=0.3), previous=_state())
+    assert features["robotwin.arm.left.joint_motion"] > MOTION_EPSILON
+    assert features["robotwin.arm.right.joint_motion"] == pytest.approx(0.0)
+    assert features[ACTIVE_ARM_FEATURE] == "left"
+
+
+def test_active_arm_is_none_when_neither_moved() -> None:
+    """A held robot must not be reported as driving an arm."""
+    features = _features(_state(), previous=_state())
+    assert features[ACTIVE_ARM_FEATURE] == "none"
+    assert features["robotwin.arm.motion_ratio"] == pytest.approx(0.0)
+
+
+def test_motion_ratio_flags_one_sided_effort() -> None:
+    """A two-handed task attempted with one hand is visible as a ratio near 1."""
+    one_sided = _features(_state(left=0.4), previous=_state())
+    balanced = _features(_state(left=0.4, right=0.4), previous=_state())
+    assert one_sided["robotwin.arm.motion_ratio"] == pytest.approx(1.0)
+    assert balanced["robotwin.arm.motion_ratio"] == pytest.approx(0.0)
+
+
+def test_stall_counters_advance_per_arm_and_reset_on_motion() -> None:
+    """A stall is evidence about one hand, so the counter is per hand."""
+    stalls = {"left": 0, "right": 0}
+    previous = _state()
+    for _ in range(3):
+        features = _features(_state(right=0.0), previous=previous, stalls=stalls)
+        stalls = next_stall_counts(features)
+    assert stalls == {"left": 3, "right": 3}
+
+    moved = _features(_state(left=0.5), previous=previous, stalls=stalls)
+    assert next_stall_counts(moved)["left"] == 0
+    assert next_stall_counts(moved)["right"] == 4
+
+
+def test_first_chunk_cannot_evidence_a_stall() -> None:
+    """With no predecessor there was no opportunity to move.
+
+    Counting it would let ``dwell_steps: 1`` fire before any motion was possible.
+    """
+    features = _features(_state(), previous=None)
+    assert next_stall_counts(features) == {"left": 0, "right": 0}
+
+
+def test_a_missing_state_degrades_instead_of_raising() -> None:
+    """The Critic is proposal-only; it must never be able to abort an episode."""
+    features = extract_robotwin_critic_features(
+        {},
+        chunk_index=0,
+        executed_horizon=25,
+        reward=0.0,
+        terminated=False,
+        truncated=False,
+    )
+    assert features["robotwin.state_available"] is False
+    assert features[ACTIVE_ARM_FEATURE] == "none"
+
+    malformed = _features([0.0] * 7, previous=_state())
+    assert malformed["robotwin.state_available"] is False
+
+
+def test_features_drive_the_shared_temporal_evaluator() -> None:
+    """The plane is only useful if a frozen rule can actually consume it."""
+    rules = critic_rules_from_payload(
+        [
+            {
+                "rule_id": "left-arm-stalled",
+                "title": "Left arm has not moved for two chunks",
+                "feature": "robotwin.arm.left.stalled_chunks",
+                "operator": "ge",
+                "threshold": 2,
+                "dwell_steps": 1,
+                "cooldown_steps": 0,
+                "proposal": "recover the left arm",
+                "evidence_ids": ["robotwin.arm.left.joint_motion"],
+                "activation_conditions": [
+                    {
+                        "feature": GRANULARITY_FEATURE,
+                        "operator": "eq",
+                        "threshold": "chunk",
+                    }
+                ],
+            }
+        ]
+    )
+    critic = TemporalCritic(rules)
+
+    stalls = {"left": 0, "right": 0}
+    previous = _state()
+    proposals: list[dict] = []
+    for index in range(3):
+        features = _features(
+            _state(), previous=previous, stalls=stalls, chunk_index=index
+        )
+        stalls = next_stall_counts(features)
+        proposals = critic.evaluate(features, step_index=index)
+    assert proposals, "a stalled left arm must eventually raise a proposal"
+    assert proposals[0]["rule_id"] == "left-arm-stalled"
+
+
+def test_proposal_arm_is_read_from_either_shape() -> None:
+    """Proposals carry the arm at the top level or inside ``details``."""
+    assert arm_from_proposal({"arm": "LEFT"}) == "left"
+    assert arm_from_proposal({"details": {"arm": "right"}}) == "right"
+    assert arm_from_proposal({"rule_id": "x"}) is None
+    # An unusable arm reads as absent, so the Actor rejects rather than guesses.
+    assert arm_from_proposal({"arm": "port"}) is None

--- a/tests/test_robotwin_role1_agent.py
+++ b/tests/test_robotwin_role1_agent.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The model-backed RoboTwin Role1.
+
+The checks worth pinning are the ones a generic adapter would not have. Role1 is
+the decision authority, so the failure that matters is not "the model said
+something malformed" -- that is caught by strict parsing -- but "the model said
+something well-formed that quietly exceeds its authority": redirecting a
+left-arm observation into a right-arm recovery, or authorising a recovery for a
+proposal that named no hand at all.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from robots.robotwin.critic_runtime import GRANULARITY_FEATURE
+from robots.robotwin.role1_agent import (
+    ModelBackedRole1,
+    Role1ContractError,
+    Role1DecisionStore,
+    Role1Event,
+    assert_seed_blind,
+    model_text,
+    parse_decision,
+    strict_model_json,
+)
+from robots.robotwin.tool_bindings import binding_for_task
+
+
+def _event(arm: str | None = "left", **overrides) -> Role1Event:
+    """Build a decision event.
+
+    Args:
+        arm: The arm the proposal's evidence concerns, or ``None``.
+        **overrides: Field overrides.
+
+    Returns:
+        The event.
+    """
+    proposal = {"rule_id": "left-arm-stalled", "proposal": "recover the arm"}
+    if arm is not None:
+        proposal["arm"] = arm
+    payload = {
+        "event_id": "role1-000001-abcdef12",
+        "task": "adjust_bottle",
+        "chunk_index": 1,
+        "proposals": (proposal,),
+        "features": {GRANULARITY_FEATURE: "chunk", "robotwin.chunk.index": 1},
+    }
+    payload.update(overrides)
+    return Role1Event(**payload)
+
+
+class _FakePlanner:
+    """A planner returning a canned assistant message."""
+
+    def __init__(self, text: str | None = None, raises: Exception | None = None):
+        """Configure the fake.
+
+        Args:
+            text: The assistant text to return.
+            raises: An exception to raise instead.
+        """
+        self.text = text
+        self.raises = raises
+        self.calls: list[dict] = []
+
+    def solve(self, *, system_prompt, user_message, toolkit, max_turns):
+        """Return the canned response."""
+        self.calls.append(
+            {"system_prompt": system_prompt, "user_message": user_message}
+        )
+        if self.raises is not None:
+            raise self.raises
+        return SimpleNamespace(
+            messages=[{"role": "assistant", "content": [{"text": self.text}]}],
+            stats={},
+            error=None,
+        )
+
+
+def _adapter(tmp_path: Path, planner: _FakePlanner, **overrides) -> ModelBackedRole1:
+    """Build an adapter over a fake planner.
+
+    Args:
+        tmp_path: Test directory.
+        planner: The fake planner.
+        **overrides: Constructor overrides.
+
+    Returns:
+        The adapter.
+    """
+    kwargs = {
+        "store": Role1DecisionStore(tmp_path / "decisions"),
+        "binding": binding_for_task("adjust_bottle"),
+        "output_root": tmp_path / "invocations",
+        "planner": planner,
+    }
+    kwargs.update(overrides)
+    return ModelBackedRole1(**kwargs)
+
+
+def _reply(event: Role1Event, **fields) -> str:
+    """Build a well-formed model reply.
+
+    Args:
+        event: The event being answered.
+        **fields: Field overrides.
+
+    Returns:
+        The JSON text.
+    """
+    payload = {
+        "event_id": event.event_id,
+        "proposal_disposition": "accept",
+        "arm": "left",
+        "reason": "the left arm has not moved for two chunks",
+    }
+    payload.update(fields)
+    return json.dumps(payload)
+
+
+# ------------------------------------------------------------ seed blindness
+
+
+def test_seed_and_rng_metadata_are_refused() -> None:
+    """A Role1 that can see the schedule is no longer deciding online."""
+    with pytest.raises(Role1ContractError, match="seed or RNG"):
+        assert_seed_blind({"seed": 7})
+    with pytest.raises(Role1ContractError, match="seed or RNG"):
+        assert_seed_blind({"outer": [{"policy_rng": 3}]})
+    with pytest.raises(Role1ContractError, match="future schedule"):
+        assert_seed_blind({"future_schedule": ["a"]})
+    with pytest.raises(Role1ContractError, match="seed value"):
+        assert_seed_blind({"note": "use seed=1234 next"})
+    assert_seed_blind({"chunk_index": 3, "arm": "left"})
+
+
+def test_model_payload_is_seed_blind_and_states_the_granularity() -> None:
+    """The model must not be asked to reason about frames it was never shown."""
+    payload = _event().model_payload()
+    assert payload["evidence"]["granularity"] == "chunk"
+    assert "no intermediate frames" in payload["evidence"]["note"]
+    assert payload["robot"]["action_space"] == "absolute joint targets"
+    assert_seed_blind(payload)
+
+
+# ----------------------------------------------------------- strict parsing
+
+
+def test_only_one_bare_json_object_is_accepted() -> None:
+    """No repair: a response that is not the contract is a contract failure."""
+    assert strict_model_json('{"a": 1}') == {"a": 1}
+    for bad in ("", "not json", "[1,2]", '{"a":1} trailing'):
+        with pytest.raises(Role1ContractError):
+            strict_model_json(bad)
+
+
+def test_repeated_keys_are_refused() -> None:
+    """A duplicate key makes the verdict ambiguous, so it is not a verdict."""
+    with pytest.raises(Role1ContractError, match="repeated JSON key"):
+        strict_model_json('{"arm": "left", "arm": "right"}')
+
+
+def test_model_text_joins_distinct_assistant_parts() -> None:
+    """Planner backends differ in how they chunk a reply."""
+    messages = [
+        {"role": "assistant", "content": [{"text": "one"}, {"text": "one"}]},
+        {"role": "assistant", "content": "two"},
+    ]
+    assert model_text(messages) == "one\ntwo"
+    with pytest.raises(Role1ContractError):
+        model_text("not a list")
+
+
+# ------------------------------------------------------- decision contract
+
+
+def test_a_well_formed_acceptance_is_parsed() -> None:
+    """The happy path still has to carry the arm it ruled on."""
+    event = _event(arm="left")
+    decision = parse_decision(json.loads(_reply(event)), event=event)
+    assert decision.accepted is True
+    assert decision.arm == "left"
+    assert decision.proposal_id == "left-arm-stalled"
+
+
+def test_the_model_may_not_redirect_the_evidence_to_the_other_hand() -> None:
+    """This is the check a single-arm adapter has no reason to have.
+
+    Accepting a right-arm recovery on left-arm evidence would leave an audit
+    trail that reads as compliant while authorising something the Critic never
+    observed.
+    """
+    event = _event(arm="left")
+    with pytest.raises(Role1ContractError, match="evidence concerns the left arm"):
+        parse_decision(json.loads(_reply(event, arm="right")), event=event)
+
+
+def test_accepting_an_arm_less_proposal_is_a_contract_failure() -> None:
+    """A RoboTwin recovery without an arm is not executable."""
+    event = _event(arm=None)
+    with pytest.raises(Role1ContractError, match="names no arm"):
+        parse_decision(json.loads(_reply(event, arm=None)), event=event)
+
+
+def test_accepting_without_naming_the_arm_is_refused() -> None:
+    """The verdict must state which hand it authorised."""
+    event = _event(arm="left")
+    payload = json.loads(_reply(event))
+    payload.pop("arm")
+    with pytest.raises(Role1ContractError, match="without naming the arm"):
+        parse_decision(payload, event=event)
+
+
+def test_a_rejection_needs_no_arm() -> None:
+    """Rejecting is always available, including when the evidence named no hand."""
+    event = _event(arm=None)
+    payload = json.loads(_reply(event, proposal_disposition="reject", arm=None))
+    decision = parse_decision(payload, event=event)
+    assert decision.accepted is False
+
+
+def test_unknown_disposition_and_wrong_event_are_refused() -> None:
+    """A verdict must answer this boundary, with one of the frozen verdicts."""
+    event = _event()
+    with pytest.raises(Role1ContractError, match="unknown proposal_disposition"):
+        parse_decision(
+            json.loads(_reply(event, proposal_disposition="modify")), event=event
+        )
+    with pytest.raises(Role1ContractError, match="different event"):
+        parse_decision(json.loads(_reply(event, event_id="other")), event=event)
+
+
+def test_missing_required_keys_are_named(tmp_path: Path) -> None:
+    """The error says which keys were missing, not merely that it failed."""
+    event = _event()
+    with pytest.raises(Role1ContractError, match="missing keys"):
+        parse_decision({"event_id": event.event_id}, event=event)
+
+
+# -------------------------------------------------------------- the adapter
+
+
+def test_adapter_persists_before_returning(tmp_path: Path) -> None:
+    """A verdict that was acted on but never recorded cannot be audited."""
+    planner = _FakePlanner()
+    adapter = _adapter(tmp_path, planner)
+    event_ids = []
+
+    def _capture(**kwargs):
+        # The event id is generated inside decide(), so answer whatever it asks.
+        payload = json.loads(kwargs["user_message"])
+        event_ids.append(payload["event_id"])
+        planner.text = json.dumps(
+            {
+                "event_id": payload["event_id"],
+                "proposal_disposition": "accept",
+                "arm": "left",
+                "reason": "stalled",
+            }
+        )
+        return _FakePlanner.solve(planner, **kwargs)
+
+    planner.solve = _capture  # type: ignore[method-assign]
+    decision = adapter.decide(
+        task="adjust_bottle",
+        chunk_index=1,
+        features={GRANULARITY_FEATURE: "chunk"},
+        proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+    )
+    assert decision.accepted is True
+    records = adapter.store.records
+    assert len(records) == 1
+    assert records[0]["evidence_arm"] == "left"
+    assert len(records[0]["record_sha256"]) == 64
+    assert (tmp_path / "decisions" / f"{event_ids[0]}.json").is_file()
+
+
+def test_a_planner_failure_rejects_rather_than_authorising(tmp_path: Path) -> None:
+    """Failing closed is the safe direction.
+
+    The opposite default -- accepting when Role1 cannot be reached -- would let
+    an outage authorise recoveries nobody ruled on.
+    """
+    adapter = _adapter(tmp_path, _FakePlanner(raises=RuntimeError("boom")))
+    decision = adapter.decide(
+        task="adjust_bottle",
+        chunk_index=0,
+        features={},
+        proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+    )
+    assert decision.accepted is False
+    assert "role1 unavailable" in decision.reason
+    assert adapter.store.records, "a failed verdict is still an audited verdict"
+
+
+def test_a_contract_violation_also_rejects(tmp_path: Path) -> None:
+    """Malformed output is a rejection, never a silently repaired acceptance."""
+    adapter = _adapter(tmp_path, _FakePlanner(text="I think you should recover."))
+    decision = adapter.decide(
+        task="adjust_bottle",
+        chunk_index=0,
+        features={},
+        proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+    )
+    assert decision.accepted is False
+    assert "Role1ContractError" in decision.reason
+
+
+def test_fail_closed_off_re_raises(tmp_path: Path) -> None:
+    """A campaign that wants failures loud can have them."""
+    adapter = _adapter(
+        tmp_path, _FakePlanner(raises=RuntimeError("boom")), fail_closed=False
+    )
+    with pytest.raises(Exception, match="boom"):
+        adapter.decide(
+            task="adjust_bottle",
+            chunk_index=0,
+            features={},
+            proposals=[{"rule_id": "x", "arm": "left"}],
+        )
+
+
+def test_no_proposal_means_no_model_call(tmp_path: Path) -> None:
+    """There is nothing to rule on, so nothing should be spent ruling."""
+    planner = _FakePlanner()
+    adapter = _adapter(tmp_path, planner)
+    decision = adapter.decide(
+        task="adjust_bottle", chunk_index=0, features={}, proposals=[]
+    )
+    assert decision.accepted is False
+    assert planner.calls == []
+
+
+def test_adapter_satisfies_the_actor_protocol(tmp_path: Path) -> None:
+    """The Actor must accept it wherever the deterministic reference goes."""
+    from robots.robotwin.role1_actor import Role1EpisodeActor
+
+    adapter = _adapter(tmp_path, _FakePlanner(raises=RuntimeError("offline")))
+    actor = Role1EpisodeActor(
+        decider=adapter, binding=binding_for_task("adjust_bottle")
+    )
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=0,
+        observation={"state": [0.0] * 14},
+        vla_actions=[[0.0] * 14],
+        critic_proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+    )
+    assert result.source == "vla"
+    assert result.decision is not None and result.decision.accepted is False

--- a/tests/test_robotwin_role1_recovery.py
+++ b/tests/test_robotwin_role1_recovery.py
@@ -1,0 +1,468 @@
+# Copyright (c) 2026 Zetta Contributors
+"""RoboTwin recovery execution and the Role1 Actor.
+
+The protocol fixes the role boundaries: the Critic proposes, Role1 rules, and
+only the Actor writes actions. What RoboTwin adds is that a recovery is not
+executable unless it names an arm, and that "the other arm holds" has to be
+composed explicitly because the robot takes absolute joint targets.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robots.robotwin.action_contract import ACTION_DIM, ARM_SLICES, GRIPPER_OFFSET
+from robots.robotwin.recovery_controller import (
+    RecoveryContractError,
+    RecoveryController,
+    validate_arm_program,
+)
+from robots.robotwin.role1_actor import (
+    GRIPPER_TOOL,
+    HOLD_TOOL,
+    ArmAwareRole1,
+    Role1ActorError,
+    Role1Decision,
+    Role1EpisodeActor,
+    action_for_recovery_step,
+)
+from robots.robotwin.tool_bindings import binding_for_task
+
+BUNDLE = "a" * 64
+
+
+def _state(left: float = 0.2, right: float = -0.3, grip: float = 0.8) -> list[float]:
+    """Build a distinguishable joint state.
+
+    Args:
+        left: Left joint value.
+        right: Right joint value.
+        grip: Gripper opening for both arms.
+
+    Returns:
+        The 14-dim state.
+    """
+    state = np.zeros(ACTION_DIM, dtype=np.float64)
+    state[ARM_SLICES["left"]] = left
+    state[ARM_SLICES["right"]] = right
+    state[GRIPPER_OFFSET] = grip
+    state[7 + GRIPPER_OFFSET] = grip
+    return list(state)
+
+
+def _recovery(arm: str = "left", tool: str = HOLD_TOOL, **arguments) -> dict:
+    """Build a frozen recovery with one step.
+
+    Args:
+        arm: The step's arm.
+        tool: The step's tool.
+        **arguments: Extra step arguments.
+
+    Returns:
+        The recovery rule.
+    """
+    step: dict = {"tool": tool, "arm": arm}
+    if arguments:
+        step["arguments"] = dict(arguments)
+    return {
+        "recovery_id": "rec-1",
+        "trigger_rule_ids": ["left-arm-stalled"],
+        "title": "Hold the stalled arm",
+        "steps": [step],
+    }
+
+
+def _controller(tmp_path: Path) -> RecoveryController:
+    """Build a controller writing into a temporary audit file.
+
+    Args:
+        tmp_path: Test directory.
+
+    Returns:
+        The controller.
+    """
+    return RecoveryController(
+        bundle_sha256=BUNDLE, audit_path=tmp_path / "recovery.jsonl"
+    )
+
+
+# --------------------------------------------------------------- arm program
+
+
+def test_arm_scoped_step_without_an_arm_is_rejected() -> None:
+    """An arm-less step is not executable; discovering that later is too late."""
+    with pytest.raises(RecoveryContractError, match="must name an arm"):
+        validate_arm_program([{"tool": HOLD_TOOL}])
+
+
+def test_non_arm_scoped_step_with_an_arm_is_rejected() -> None:
+    """A stray arm means the candidate misunderstood the tool."""
+    with pytest.raises(RecoveryContractError, match="not arm-scoped"):
+        validate_arm_program([{"tool": "robotwin.verify.state", "arm": "left"}])
+
+
+def test_unknown_step_tool_is_rejected() -> None:
+    """A step is only as trustworthy as the catalog that declares its tool."""
+    with pytest.raises(RecoveryContractError, match="does not declare"):
+        validate_arm_program([{"tool": "robotwin.ghost", "arm": "left"}])
+
+
+def test_valid_program_resolves_one_arm_per_step() -> None:
+    """The resolved program is what execution is later verified against."""
+    program = validate_arm_program(
+        [
+            {"tool": HOLD_TOOL, "arm": "LEFT"},
+            {"tool": "robotwin.verify.state"},
+        ]
+    )
+    assert program == ("left", None)
+
+
+# ------------------------------------------------------------- controller
+
+
+def test_activation_validates_the_whole_program_up_front(tmp_path: Path) -> None:
+    """A bad step must not be found halfway, after the episode was perturbed."""
+    controller = _controller(tmp_path)
+    broken = _recovery()
+    broken["steps"].append({"tool": HOLD_TOOL})  # no arm
+    with pytest.raises(RecoveryContractError):
+        controller.activate(
+            critic_proposals=[{"rule_id": "left-arm-stalled"}],
+            recovery_rules=[broken],
+            environment_step=0,
+        )
+    assert controller.active is False
+
+
+def test_activation_exposes_the_step_arm(tmp_path: Path) -> None:
+    """The Actor needs the arm to compose joint targets."""
+    controller = _controller(tmp_path)
+    assert controller.activate(
+        critic_proposals=[{"rule_id": "left-arm-stalled"}],
+        recovery_rules=[_recovery(arm="right")],
+        environment_step=3,
+    )
+    context = controller.context()
+    assert context["current_step_arm"] == "right"
+    assert context["remaining_steps"] == 1
+
+
+def test_executing_the_wrong_arm_is_refused(tmp_path: Path) -> None:
+    """Otherwise a left-arm recovery could be 'satisfied' by the right arm."""
+    controller = _controller(tmp_path)
+    controller.activate(
+        critic_proposals=[{"rule_id": "left-arm-stalled"}],
+        recovery_rules=[_recovery(arm="left")],
+        environment_step=0,
+    )
+    with pytest.raises(RecoveryContractError, match="drove"):
+        controller.complete_current_step(
+            selected_tool=HOLD_TOOL,
+            environment_step=1,
+            executed_horizon=25,
+            executed_arm="right",
+        )
+    with pytest.raises(RecoveryContractError, match="reported no arm"):
+        controller.complete_current_step(
+            selected_tool=HOLD_TOOL, environment_step=1, executed_horizon=25
+        )
+    # Still active: a refused step must not silently advance the program.
+    assert controller.active is True
+
+
+def test_matching_arm_completes_the_step(tmp_path: Path) -> None:
+    """The happy path advances and writes a durable audit row."""
+    controller = _controller(tmp_path)
+    controller.activate(
+        critic_proposals=[{"rule_id": "left-arm-stalled"}],
+        recovery_rules=[_recovery(arm="left")],
+        environment_step=0,
+    )
+    state = controller.complete_current_step(
+        selected_tool=HOLD_TOOL,
+        environment_step=25,
+        executed_horizon=25,
+        executed_arm="left",
+    )
+    assert state.status == "completed"
+    assert controller.active is False
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "recovery.jsonl").read_text().splitlines()
+    ]
+    assert [row["event"] for row in rows] == ["activated", "completed"]
+    assert rows[-1]["executed_arm"] == "left"
+
+
+def test_an_active_recovery_is_never_restarted(tmp_path: Path) -> None:
+    """A fresh proposal must not erase a bounded program mid-flight."""
+    controller = _controller(tmp_path)
+    controller.activate(
+        critic_proposals=[{"rule_id": "left-arm-stalled"}],
+        recovery_rules=[_recovery()],
+        environment_step=0,
+    )
+    assert (
+        controller.activate(
+            critic_proposals=[{"rule_id": "left-arm-stalled"}],
+            recovery_rules=[_recovery()],
+            environment_step=1,
+        )
+        is False
+    )
+
+
+# ------------------------------------------------------------------ actions
+
+
+def test_holding_one_arm_still_sends_the_other_arm_its_measured_pose() -> None:
+    """This is the whole reason the Actor composes rather than slices.
+
+    RoboTwin takes absolute targets, so a 'hold the left arm' step must still
+    say what the right arm does -- and the only correct answer is where it is.
+    """
+    state = _state(left=0.2, right=-0.3)
+    action = action_for_recovery_step(
+        {"tool": HOLD_TOOL, "arm": "left"}, arm="left", observation={"state": state}
+    )
+    assert action.arm_half("left") == tuple(state[ARM_SLICES["left"]])
+    assert action.arm_half("right") == tuple(state[ARM_SLICES["right"]])
+    assert not np.allclose(action.as_array()[ARM_SLICES["right"]], 0.0)
+
+
+def test_gripper_step_moves_only_the_gripper() -> None:
+    """The six joints repeat, so the arm does not drift while the hand closes."""
+    state = _state(grip=0.9)
+    action = action_for_recovery_step(
+        {"tool": GRIPPER_TOOL, "arm": "right", "arguments": {"opening": 0.0}},
+        arm="right",
+        observation={"state": state},
+    )
+    right = action.arm_half("right")
+    assert right[GRIPPER_OFFSET] == pytest.approx(0.0)
+    assert right[:GRIPPER_OFFSET] == tuple(state[ARM_SLICES["right"]][:GRIPPER_OFFSET])
+    assert action.arm_half("left")[GRIPPER_OFFSET] == pytest.approx(0.9)
+
+
+def test_unexecutable_step_tool_is_refused_not_approximated() -> None:
+    """Substituting a different motion would make the audit trail lie."""
+    with pytest.raises(Role1ActorError, match="cannot turn"):
+        action_for_recovery_step(
+            {"tool": "robotwin.arm.select", "arm": "left"},
+            arm="left",
+            observation={"state": _state()},
+        )
+
+
+def test_missing_state_refuses_rather_than_zero_filling() -> None:
+    """Guessing the idle arm's pose is exactly the mistake to avoid."""
+    with pytest.raises(Role1ActorError, match="no joint state"):
+        action_for_recovery_step(
+            {"tool": HOLD_TOOL, "arm": "left"}, arm="left", observation={}
+        )
+
+
+def test_gripper_step_requires_an_opening() -> None:
+    """An under-specified step is a candidate defect, not a default."""
+    with pytest.raises(Role1ActorError, match="opening"):
+        action_for_recovery_step(
+            {"tool": GRIPPER_TOOL, "arm": "left"},
+            arm="left",
+            observation={"state": _state()},
+        )
+
+
+# -------------------------------------------------------------------- Role1
+
+
+def _actor(tmp_path: Path, **overrides) -> Role1EpisodeActor:
+    """Build an Actor bound to ``adjust_bottle``.
+
+    Args:
+        tmp_path: Test directory.
+        **overrides: Constructor overrides.
+
+    Returns:
+        The Actor.
+    """
+    kwargs = {
+        "decider": ArmAwareRole1(),
+        "binding": binding_for_task("adjust_bottle"),
+        "recovery": _controller(tmp_path),
+    }
+    kwargs.update(overrides)
+    return Role1EpisodeActor(**kwargs)
+
+
+def _vla(rows: int = 2) -> list[list[float]]:
+    """Build a plausible policy chunk.
+
+    Args:
+        rows: Number of actions.
+
+    Returns:
+        A ``[rows, 14]`` chunk.
+    """
+    return [list(np.full(ACTION_DIM, 0.05 * (index + 1))) for index in range(rows)]
+
+
+def test_reference_role1_rejects_a_proposal_that_names_no_arm(tmp_path: Path) -> None:
+    """A RoboTwin recovery cannot run without an arm, however good the evidence."""
+    actor = _actor(tmp_path)
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=0,
+        observation={"state": _state()},
+        vla_actions=_vla(),
+        critic_proposals=[{"rule_id": "stalled", "proposal": "do something"}],
+        recovery_rules=[_recovery()],
+    )
+    assert result.source == "vla"
+    assert result.decision is not None
+    assert result.decision.accepted is False
+    assert "names no arm" in result.decision.reason
+
+
+def test_accepted_proposal_activates_and_executes_the_recovery(
+    tmp_path: Path,
+) -> None:
+    """An arm-named proposal reaches the frozen program."""
+    actor = _actor(tmp_path)
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=1,
+        observation={"state": _state()},
+        vla_actions=_vla(),
+        critic_proposals=[
+            {"rule_id": "left-arm-stalled", "arm": "left", "proposal": "hold it"}
+        ],
+        recovery_rules=[_recovery(arm="left")],
+    )
+    assert result.source == "recovery"
+    assert result.selected_tool == HOLD_TOOL
+    assert result.commanded_arms == ("left",)
+    assert result.decision is not None and result.decision.accepted
+
+
+def test_an_unexecutable_frozen_program_falls_back_to_the_policy(
+    tmp_path: Path,
+) -> None:
+    """A candidate defect must not stall the episode; the audit says why."""
+    broken = _recovery()
+    broken["steps"] = [{"tool": HOLD_TOOL}]  # arm-scoped, no arm
+    actor = _actor(tmp_path)
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=0,
+        observation={"state": _state()},
+        vla_actions=_vla(),
+        critic_proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+        recovery_rules=[broken],
+    )
+    assert result.source == "vla"
+    assert result.decision is not None
+    assert "recovery rejected" in result.decision.reason
+
+
+def test_a_running_recovery_owns_the_boundary(tmp_path: Path) -> None:
+    """A fresh policy chunk must not erase a bounded program mid-flight."""
+    controller = _controller(tmp_path)
+    controller.activate(
+        critic_proposals=[{"rule_id": "left-arm-stalled"}],
+        recovery_rules=[_recovery(arm="right")],
+        environment_step=0,
+    )
+    actor = _actor(tmp_path, recovery=controller)
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=5,
+        observation={"state": _state()},
+        vla_actions=_vla(),
+    )
+    assert result.source == "recovery"
+    assert result.commanded_arms == ("right",)
+
+
+def test_policy_chunk_passes_through_when_nothing_is_proposed(
+    tmp_path: Path,
+) -> None:
+    """The common path stays the policy's own chunk."""
+    actor = _actor(tmp_path)
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=0,
+        observation={"state": _state()},
+        vla_actions=_vla(rows=3),
+    )
+    assert result.source == "vla"
+    assert len(result.actions) == 3
+    assert result.commanded_arms == ("left", "right")
+    assert result.decision is None
+
+
+def test_task_must_match_the_frozen_binding(tmp_path: Path) -> None:
+    """An Actor bound to one task must not silently serve another."""
+    actor = _actor(tmp_path)
+    with pytest.raises(Role1ActorError, match="does not match"):
+        actor.decide_action(
+            task="lift_pot",
+            chunk_index=0,
+            observation={"state": _state()},
+            vla_actions=_vla(),
+        )
+
+
+def test_malformed_policy_chunk_is_refused(tmp_path: Path) -> None:
+    """A half-width chunk reaching a bimanual robot must fail loudly."""
+    actor = _actor(tmp_path)
+    with pytest.raises(Role1ActorError, match="not a valid action"):
+        actor.decide_action(
+            task="adjust_bottle",
+            chunk_index=0,
+            observation={"state": _state()},
+            vla_actions=[[0.0] * 7],
+        )
+    with pytest.raises(Role1ActorError, match="empty action chunk"):
+        actor.decide_action(
+            task="adjust_bottle",
+            chunk_index=0,
+            observation={"state": _state()},
+            vla_actions=[],
+        )
+
+
+def test_repeated_holds_terminate_the_episode(tmp_path: Path) -> None:
+    """A boundary that never produces motion must be bounded, not infinite."""
+    actor = _actor(tmp_path, maximum_rejections_without_action=2)
+    observation = {"state": _state()}
+    first = actor.hold(observation)
+    assert first.terminate is False
+    second = actor.hold(observation)
+    assert second.terminate is True
+    assert "2 consecutive boundaries" in second.termination_reason
+
+
+def test_a_custom_decider_can_veto(tmp_path: Path) -> None:
+    """Role1 is the decision authority; the Critic only proposes."""
+
+    class _AlwaysReject:
+        def decide(self, **_kwargs) -> Role1Decision:
+            return Role1Decision(accepted=False, reason="vetoed")
+
+    actor = _actor(tmp_path, decider=_AlwaysReject())
+    result = actor.decide_action(
+        task="adjust_bottle",
+        chunk_index=0,
+        observation={"state": _state()},
+        vla_actions=_vla(),
+        critic_proposals=[{"rule_id": "left-arm-stalled", "arm": "left"}],
+        recovery_rules=[_recovery(arm="left")],
+    )
+    assert result.source == "vla"
+    assert result.decision.reason == "vetoed"

--- a/tests/test_robotwin_tool_catalog.py
+++ b/tests/test_robotwin_tool_catalog.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Zetta Contributors
+"""The RoboTwin tool catalog and task bindings.
+
+The catalog is content-hashed into a campaign manifest and cannot be edited once
+a campaign is running, so the tests here are less about behaviour than about
+pinning the things that would be expensive to get wrong: that the arm
+requirement is a **declared, hashed** property rather than a documentation
+convention, and that the digest actually moves when a declaration does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robots.robotwin.action_contract import ArmSelectionError
+from robots.robotwin.tool_bindings import TaskToolBinding, binding_for_task
+from robots.robotwin.tool_catalog import (
+    DEFAULT_ROBOTWIN_TOOL_CATALOG,
+    TOOL_NAMESPACE,
+    ToolCatalog,
+    ToolSpec,
+    build_robotwin_tool_catalog,
+)
+
+
+def _spec(name: str = "robotwin.test.tool", **overrides) -> ToolSpec:
+    """Build a minimal valid declaration.
+
+    Args:
+        name: Tool name.
+        **overrides: Field overrides.
+
+    Returns:
+        The declaration.
+    """
+    payload = {
+        "name": name,
+        "description": "A test tool.",
+        "capabilities": ("test.capability",),
+    }
+    payload.update(overrides)
+    return ToolSpec(**payload)
+
+
+def test_every_tool_uses_the_robotwin_namespace() -> None:
+    """A stray namespace would collide with another robot's catalog."""
+    for name in DEFAULT_ROBOTWIN_TOOL_CATALOG.names():
+        assert name.startswith(TOOL_NAMESPACE)
+    with pytest.raises(ValueError, match="must start with"):
+        _spec("robocasa.borrowed.tool")
+
+
+def test_catalog_digest_is_stable_across_rebuilds() -> None:
+    """Two builds of the same declarations must hash identically."""
+    assert build_robotwin_tool_catalog().digest == DEFAULT_ROBOTWIN_TOOL_CATALOG.digest
+
+
+def test_arm_requirement_is_part_of_the_hash() -> None:
+    """Flipping ``arm_scoped`` must change the catalog digest.
+
+    If it did not, a campaign's frozen manifest could not distinguish a catalog
+    where a tool required an arm from one where it did not -- which is exactly
+    the mistake this field exists to prevent.
+    """
+    base = ToolCatalog([_spec(arm_scoped=False)])
+    scoped = ToolCatalog([_spec(arm_scoped=True)])
+    assert base.digest != scoped.digest
+    assert "arm_scoped" in base.public_dict()["tools"][0]
+
+
+def test_arm_scoped_tools_reject_an_invocation_without_an_arm() -> None:
+    """The arm is enforced by the schema, not by the implementation's choice."""
+    spec = _spec(arm_scoped=True)
+    with pytest.raises(ValueError, match="must name an arm"):
+        spec.validate_arguments({})
+    assert spec.validate_arguments({"arm": "LEFT"}) == "left"
+    with pytest.raises(ArmSelectionError):
+        spec.validate_arguments({"arm": "port"})
+
+
+def test_non_arm_scoped_tools_reject_a_stray_arm_argument() -> None:
+    """An arm on a whole-robot tool means the caller misunderstood it."""
+    spec = _spec(arm_scoped=False)
+    assert spec.validate_arguments({}) is None
+    with pytest.raises(ValueError, match="not arm-scoped"):
+        spec.validate_arguments({"arm": "left"})
+
+
+def test_the_shipped_catalog_marks_the_right_tools_arm_scoped() -> None:
+    """Anything that moves or reads a specific hand must be arm-scoped."""
+    scoped = set(DEFAULT_ROBOTWIN_TOOL_CATALOG.arm_scoped_names())
+    assert "robotwin.control.hold_arm" in scoped
+    assert "robotwin.gripper.set" in scoped
+    assert "robotwin.arm.read_joint_state" in scoped
+    # Whole-robot tools must not be: the VLA emits both arms at once, and arm
+    # *selection* is precisely the thing that has no arm yet.
+    assert "robotwin.vla.pi05" not in scoped
+    assert "robotwin.arm.select" not in scoped
+    assert "robotwin.observation.view_driver_state" not in scoped
+
+
+def test_hold_arm_is_declared_because_zero_is_not_a_hold() -> None:
+    """The declaration carries the reason, so a candidate writer sees it."""
+    spec = DEFAULT_ROBOTWIN_TOOL_CATALOG.get("robotwin.control.hold_arm")
+    assert "absolute targets" in spec.description
+    assert spec.proposal_only is True
+
+
+def test_catalog_selection_fails_closed_on_unknown_names() -> None:
+    """A policy naming a tool that does not exist must not silently shrink."""
+    with pytest.raises(KeyError, match="unknown RoboTwin tools"):
+        DEFAULT_ROBOTWIN_TOOL_CATALOG.select(allow=["robotwin.not.a.tool"])
+
+
+def test_duplicate_declarations_are_rejected() -> None:
+    """A duplicate would make the digest depend on iteration order."""
+    with pytest.raises(ValueError, match="duplicate"):
+        ToolCatalog([_spec(), _spec()])
+
+
+def test_adjust_bottle_binding_carries_the_arm_group() -> None:
+    """The task is judged on using the *correct* arm, so the group is bound."""
+    binding = binding_for_task("adjust_bottle")
+    assert binding.vla_tool_name in binding.tool_names
+    assert "robotwin.arm.select" in binding.tool_names
+    assert set(binding.arm_scoped_tool_names) <= set(binding.tool_names)
+    assert binding.arm_scoped_tool_names, "a bimanual task must bind arm-scoped tools"
+    assert len(binding.digest) == 64
+
+
+def test_binding_rejects_tools_outside_the_catalog() -> None:
+    """A binding is only as trustworthy as the catalog it resolves against."""
+    with pytest.raises(ValueError, match="unknown tools"):
+        TaskToolBinding(task="x", tool_names=("robotwin.vla.pi05", "robotwin.ghost"))
+
+
+def test_binding_requires_a_selectable_vla_tool() -> None:
+    """An unreachable action source would leave the episode with no policy."""
+    with pytest.raises(ValueError, match="VLA tool"):
+        TaskToolBinding(task="x", tool_names=("robotwin.verify.state",))
+
+
+def test_unknown_task_fails_closed() -> None:
+    """No binding means no audited tool set; that must not be improvised."""
+    with pytest.raises(KeyError, match="no audited tool binding"):
+        binding_for_task("place_empty_cup")

--- a/tests/test_zetta_robotwin_contract.py
+++ b/tests/test_zetta_robotwin_contract.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Contract tests for the vendored RoboTwin env helpers.
+
+These cover the three pieces of ``zetta/envs/robotwin/`` that are reachable
+without a simulator: the TensorFlow-free centre crop, the success-seed
+partition, and the multiprocessing start-method guard. The env class itself
+needs ``robotwin`` + SAPIEN and is exercised on a GPU host instead.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from zetta.envs.robotwin.utils import (
+    CROP_OUTPUT_SIZE,
+    CROP_SCALE,
+    center_crop_image,
+)
+
+
+def _frame(height: int = 240, width: int = 320) -> np.ndarray:
+    """Build a deterministic uint8 RGB frame.
+
+    Args:
+        height: Frame height.
+        width: Frame width.
+
+    Returns:
+        An ``HxWx3`` uint8 array with a distinguishable gradient.
+    """
+    ys = np.linspace(0, 255, height, dtype=np.float64)[:, None]
+    xs = np.linspace(0, 255, width, dtype=np.float64)[None, :]
+    red = np.broadcast_to(ys, (height, width))
+    green = np.broadcast_to(xs, (height, width))
+    blue = (ys + xs) / 2.0
+    return np.stack([red, green, blue], axis=-1).astype(np.uint8)
+
+
+def test_center_crop_maps_robotwin_frames_to_the_model_resolution() -> None:
+    """RoboTwin's native 240x320 frame becomes the 224x224 the Pi0 stack wants."""
+    cropped = center_crop_image(_frame())
+    assert cropped.shape == (CROP_OUTPUT_SIZE[1], CROP_OUTPUT_SIZE[0], 3)
+    assert cropped.dtype == np.uint8
+
+
+def test_center_crop_keeps_the_centre_of_the_frame() -> None:
+    """The crop is centred, so a bright centre patch survives and a corner does not."""
+    frame = np.zeros((240, 320, 3), dtype=np.uint8)
+    frame[110:130, 150:170] = 255  # centre patch
+    cropped = center_crop_image(frame)
+    assert cropped.max() == 255
+
+    corner_only = np.zeros((240, 320, 3), dtype=np.uint8)
+    corner_only[0:4, 0:4] = 255  # outside sqrt(0.9) of each side
+    assert center_crop_image(corner_only).max() == 0
+
+
+def test_center_crop_scale_is_an_area_fraction() -> None:
+    """``CROP_SCALE`` is an area fraction, so each side keeps ``sqrt(CROP_SCALE)``."""
+    assert 0.0 < CROP_SCALE <= 1.0
+    # A square input makes the linear fraction directly observable: with
+    # crop_scale=0.25 exactly half of each side is kept.
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    frame[25:75, 25:75] = 255
+    kept = center_crop_image(frame, crop_scale=0.25, output_size=(50, 50))
+    assert kept.min() == 255
+
+
+def test_center_crop_accepts_grayscale_and_returns_rgb() -> None:
+    """A single-channel frame is widened to RGB rather than rejected."""
+    gray = np.full((240, 320), 128, dtype=np.uint8)
+    out = center_crop_image(gray)
+    assert out.shape == (224, 224, 3)
+
+
+def test_center_crop_rejects_a_non_image() -> None:
+    """A 1-D array has no height/width and must fail loudly."""
+    with pytest.raises(ValueError, match="H and W"):
+        center_crop_image(np.zeros(8, dtype=np.uint8))
+
+
+def test_success_seed_partition_is_disjoint_and_deterministic() -> None:
+    """Every worker derives the same permutation and takes a disjoint slice."""
+    torch = pytest.importorskip("torch")
+    from zetta.envs.robotwin.utils import partition_success_seeds
+
+    seeds = torch.arange(100, 140, dtype=torch.long)
+    slices = [
+        partition_success_seeds(
+            seeds,
+            base_seed=7,
+            seed_offset=offset,
+            total_num_processes=4,
+            num_group=2,
+        )
+        for offset in range(4)
+    ]
+
+    assert all(s.numel() == 10 for s in slices)
+    flat = torch.cat(slices)
+    assert flat.numel() == len(set(flat.tolist())), "worker slices overlap"
+
+    again = partition_success_seeds(
+        seeds, base_seed=7, seed_offset=1, total_num_processes=4, num_group=2
+    )
+    assert torch.equal(again, slices[1])
+
+    shifted = partition_success_seeds(
+        seeds, base_seed=8, seed_offset=1, total_num_processes=4, num_group=2
+    )
+    assert not torch.equal(shifted, slices[1]), "base_seed must drive the shuffle"
+
+
+def test_success_seed_partition_truncates_to_whole_groups() -> None:
+    """A slice that does not divide by ``num_group`` is trimmed, not padded."""
+    torch = pytest.importorskip("torch")
+    from zetta.envs.robotwin.utils import partition_success_seeds
+
+    seeds = torch.arange(0, 21, dtype=torch.long)  # 21 seeds, 2 workers -> 10 each
+    got = partition_success_seeds(
+        seeds, base_seed=1, seed_offset=0, total_num_processes=2, num_group=4
+    )
+    assert got.numel() == 8  # 10 trimmed down to a multiple of 4
+
+
+def test_spawn_guard_is_idempotent() -> None:
+    """Calling the guard twice leaves ``spawn`` in place and warns only on a change."""
+    pytest.importorskip("torch")
+    import warnings
+
+    import torch.multiprocessing as mp
+
+    from zetta.envs.robotwin.utils import ensure_spawn_start_method
+
+    original = mp.get_start_method(allow_none=True)
+    try:
+        assert ensure_spawn_start_method() == "spawn"
+        assert mp.get_start_method(allow_none=True) == "spawn"
+
+        # Second call must be a silent no-op: the override warning is only for
+        # the case where a different method was actually displaced.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert ensure_spawn_start_method() == "spawn"
+        assert not caught, f"unexpected warning(s): {[str(w.message) for w in caught]}"
+    finally:
+        if original is not None:
+            mp.set_start_method(original, force=True)
+
+
+def test_spawn_guard_warns_when_it_displaces_another_method() -> None:
+    """Overriding a live start method is a process-global act and must be loud."""
+    pytest.importorskip("torch")
+    import multiprocessing
+    import warnings
+
+    import torch.multiprocessing as mp
+
+    from zetta.envs.robotwin.utils import ensure_spawn_start_method
+
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("platform has no 'fork' start method to displace")
+
+    original = mp.get_start_method(allow_none=True)
+    try:
+        mp.set_start_method("fork", force=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert ensure_spawn_start_method() == "spawn"
+        assert any("spawn" in str(w.message) for w in caught)
+    finally:
+        if original is not None:
+            mp.set_start_method(original, force=True)
+
+
+def test_prepare_actions_passes_robotwin_chunks_through_unchanged() -> None:
+    """RoboTwin consumes ALOHA joint targets directly, so the transform is identity.
+
+    The delta-vs-absolute split (deltas on the 6 joints, absolute on the
+    gripper, per arm) already happened inside the data config's
+    ``DeltaActions``/``AbsoluteActions``; re-applying anything here would
+    double-count it.
+    """
+    pytest.importorskip("torch")
+    from zetta.compat.actions import prepare_actions
+
+    chunk = np.arange(2 * 3 * 14, dtype=np.float32).reshape(2, 3, 14)
+    out = prepare_actions(
+        chunk,
+        env_type="robotwin",
+        model_type="openpi",
+        num_action_chunks=3,
+        action_dim=14,
+    )
+    assert np.array_equal(np.asarray(out), chunk)
+
+
+def test_prepare_actions_rejects_single_arm_width_for_robotwin() -> None:
+    """A 7-dim chunk reaching a bimanual env is the mistake worth failing on.
+
+    Without an explicit branch this would ride the function's fall-through
+    identity return and silently feed half-width actions to a 14-DoF robot.
+    """
+    pytest.importorskip("torch")
+    from zetta.compat.actions import prepare_actions
+
+    with pytest.raises(ValueError, match="bimanual"):
+        prepare_actions(
+            np.zeros((1, 4, 7), dtype=np.float32),
+            env_type="robotwin",
+            model_type="openpi",
+            num_action_chunks=4,
+            action_dim=7,
+        )
+
+
+def test_prepare_actions_rejects_a_mismatched_trailing_axis() -> None:
+    """A declared 14 with a 7-wide array must not pass either."""
+    pytest.importorskip("torch")
+    from zetta.compat.actions import prepare_actions
+
+    with pytest.raises(ValueError, match="trailing dimension"):
+        prepare_actions(
+            np.zeros((1, 4, 7), dtype=np.float32),
+            env_type="robotwin",
+            model_type="openpi",
+            num_action_chunks=4,
+            action_dim=14,
+        )

--- a/zetta/compat/actions.py
+++ b/zetta/compat/actions.py
@@ -64,6 +64,50 @@ def prepare_actions_for_maniskill(
     return actions.reshape(-1, num_action_chunks, action_dim)
 
 
+ROBOTWIN_ACTION_DIM = 14
+"""RoboTwin's ALOHA-style bimanual action width: 6 joints + 1 gripper per arm."""
+
+
+def prepare_actions_for_robotwin(raw_chunk_actions, action_dim: int) -> np.ndarray:
+    """Pass RoboTwin's bimanual joint actions through unchanged.
+
+    RoboTwin consumes absolute ALOHA joint targets, and the Pi0/Pi0.5 pipeline
+    already emits them in that space: the padded 32-dim model output is sliced
+    back to 14 by ``AlohaOutputs``, and the delta-vs-absolute split (deltas on
+    the 6 joints, absolute on the gripper, per arm) is applied by
+    ``DeltaActions``/``AbsoluteActions`` inside the data config. So the correct
+    transform here is the identity -- re-applying any of it would double-count.
+
+    This exists as an explicit branch rather than riding the fall-through
+    identity return: the fall-through also silently accepts a wrong
+    ``action_dim``, and a 7-dim single-arm chunk reaching a bimanual env is
+    exactly the mistake worth failing on.
+
+    Args:
+        raw_chunk_actions: ``[num_envs, chunk, action_dim]`` actions.
+        action_dim: Declared action width; must be 14.
+
+    Returns:
+        The actions unchanged.
+
+    Raises:
+        ValueError: ``action_dim`` is not 14, or the trailing axis disagrees
+            with it.
+    """
+    if action_dim != ROBOTWIN_ACTION_DIM:
+        raise ValueError(
+            f"RoboTwin is bimanual and requires action_dim="
+            f"{ROBOTWIN_ACTION_DIM}, got {action_dim}"
+        )
+    actual = np.shape(raw_chunk_actions)[-1]
+    if actual != ROBOTWIN_ACTION_DIM:
+        raise ValueError(
+            f"RoboTwin action chunk has trailing dimension {actual}, "
+            f"expected {ROBOTWIN_ACTION_DIM}"
+        )
+    return raw_chunk_actions
+
+
 def prepare_actions(
     raw_chunk_actions,
     env_type: str,
@@ -92,4 +136,6 @@ def prepare_actions(
             action_scale,
             policy,
         )
+    if normalized_env_type == "robotwin":
+        return prepare_actions_for_robotwin(raw_chunk_actions, action_dim)
     return raw_chunk_actions

--- a/zetta/envs/robotwin/__init__.py
+++ b/zetta/envs/robotwin/__init__.py
@@ -1,0 +1,26 @@
+"""RoboTwin 2.0 environment integration owned by Zetta."""
+
+__all__ = ["RoboTwinEnv"]
+
+
+def __getattr__(name: str):
+    """Import ``RoboTwinEnv`` lazily.
+
+    The module pulls in ``gymnasium`` and, at construction time, the ``robotwin``
+    package, neither of which exists in the minimal test environment. Keeping
+    the import lazy means ``import zetta.envs.robotwin`` stays cheap and safe.
+
+    Args:
+        name: Attribute being looked up.
+
+    Returns:
+        The ``RoboTwinEnv`` class.
+
+    Raises:
+        AttributeError: Any other attribute name.
+    """
+    if name == "RoboTwinEnv":
+        from zetta.envs.robotwin.environment import RoboTwinEnv
+
+        return RoboTwinEnv
+    raise AttributeError(name)

--- a/zetta/envs/robotwin/environment.py
+++ b/zetta/envs/robotwin/environment.py
@@ -1,0 +1,817 @@
+"""RoboTwin 2.0 environment, adapted from RLinf's ``envs/robotwin/robotwin_env.py``.
+
+The class shape is kept verbatim so it stays diffable against upstream: the same
+constructor signature every rlinf env family shares
+(``cfg, num_envs, seed_offset, total_num_processes, worker_info``), the same
+``reset``/``step``/``chunk_step``/``update_reset_state_ids``/``is_start`` surface.
+
+Five deliberate deviations from upstream, all of them forced:
+
+1. RLinf package imports are replaced with Zetta-local ones
+   (``rlinf.envs.utils`` -> :mod:`zetta.compat.tensors` and
+   :mod:`zetta.envs.robotwin.utils`; ``rlinf.envs.robotwin.seed_utils`` ->
+   the same local utils module).
+2. ``center_crop_image`` no longer goes through TensorFlow -- see
+   :mod:`zetta.envs.robotwin.utils`.
+3. The process-global ``mp.set_start_method("spawn", force=True)`` becomes
+   :func:`~zetta.envs.robotwin.utils.ensure_spawn_start_method`, which is
+   idempotent and warns when it actually overrides something.
+4. ``omegaconf`` is imported lazily and ``task_config`` may be a plain dict, so
+   the class is constructible (and testable) without OmegaConf in the way.
+5. Upstream's ``sample_action_space`` is **dropped**: it reads ``self.horizon``,
+   which is never assigned anywhere in the class, so calling it always raises
+   ``AttributeError``. Nothing in the Rollout Runtime path uses it.
+6. ``_extract_obs_image`` additionally returns ``wrist_image_names``. Upstream
+   stacks whichever wrist frames happen to be present, so index 0 means "left
+   wrist" only when a left wrist exists -- with a right-wrist-only config it
+   silently means the right one. The Runtime maps left and right to *different*
+   ``Observation`` fields (D1), and getting that backwards is a silent
+   wrong-data bug, so the stack is made self-describing. Purely additive: the
+   existing four keys are unchanged.
+
+**Observation shapes**, as measured against RoboTwin
+``0008ae6800df9f75fc8de7098bacb01735fd8fd2`` (``adjust_bottle``, aloha-agilex):
+``full_image`` / ``left_wrist_image`` / ``right_wrist_image`` are
+``(240, 320, 3)`` uint8, ``state`` is ``(14,)`` **float64**, ``instruction`` is a
+string. ``center_crop=True`` is what brings frames to ``(224, 224, 3)``.
+``states`` is left float64 here to stay faithful to upstream; the float32
+normalisation the Runtime's ``Observation``/``obs_schema_digest`` requires
+happens in ``rollout_runtime/backends/rlinf_robotwin.py``, which is where the
+schema contract lives.
+
+``chunk_step`` submits the **whole chunk** in one ``venv.step`` call and returns
+an ``obs_list`` of length 1 regardless of the chunk length -- this is the sole
+``final_only`` family in the codebase and the reason
+``core/env_execution.py::normalize_chunk_outcome`` exists.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Optional, Union
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from zetta.compat.tensors import list_of_dict_to_dict_of_list
+from zetta.envs.robotwin.utils import (
+    center_crop_image,
+    ensure_spawn_start_method,
+    partition_success_seeds,
+)
+
+__all__ = ["RoboTwinEnv"]
+
+
+def _as_container(value: Any) -> Any:
+    """Return a plain Python container for an OmegaConf node or a dict.
+
+    Args:
+        value: An OmegaConf ``DictConfig``/``ListConfig``, or an already-plain
+            value.
+
+    Returns:
+        The plain-Python equivalent; ``value`` unchanged when it is not an
+        OmegaConf node.
+    """
+    try:
+        from omegaconf import OmegaConf
+    except ImportError:
+        return value
+    if OmegaConf.is_config(value):
+        return OmegaConf.to_container(value, resolve=True)
+    return value
+
+
+def _cfg_get(cfg: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from an OmegaConf node, a mapping, or an object.
+
+    Args:
+        cfg: The configuration holder.
+        key: Attribute or item name.
+        default: Value to return when the key is absent.
+
+    Returns:
+        The configured value, or ``default``.
+    """
+    getter = getattr(cfg, "get", None)
+    if callable(getter):
+        try:
+            return getter(key, default)
+        except TypeError:
+            pass
+    return getattr(cfg, key, default)
+
+
+def _ensure_robotwin_importable(repository_root: str) -> None:
+    """Put the RoboTwin repository root on ``sys.path`` if it is not already.
+
+    RoboTwin ships two importable trees at its root: the ``robotwin`` package
+    (``robotwin.envs.vector_env``) and a bare top-level ``envs`` package that
+    ``vector_env`` itself imports with ``from envs import *``. Both need the
+    repository root on the path, so adding it once covers the pair.
+
+    A no-op when ``robotwin`` already imports, so an operator who has exported
+    ``PYTHONPATH`` the upstream way keeps exactly the behaviour they set up.
+
+    Args:
+        repository_root: The RoboTwin checkout root (the configured
+            ``assets_path``).
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("robotwin") is not None:
+        return
+    root = os.path.abspath(repository_root)
+    if os.path.isdir(os.path.join(root, "robotwin")) and root not in sys.path:
+        sys.path.insert(0, root)
+
+
+class RoboTwinEnv(gym.Env):
+    """RoboTwin 2.0 bimanual environment wrapper."""
+
+    def __init__(
+        self,
+        cfg,
+        num_envs,
+        seed_offset,
+        total_num_processes,
+        worker_info,
+        record_metrics=True,
+    ):
+        """Build the vectorised RoboTwin environment.
+
+        Args:
+            cfg: Env configuration (``seed``, ``auto_reset``, ``group_size``,
+                ``assets_path``, ``seeds_path``, ``task_config``, ...).
+            num_envs: Number of lanes this instance owns.
+            seed_offset: This worker's index, used for both the seed and the
+                success-seed partition.
+            total_num_processes: Number of workers sharing the seed pool.
+            worker_info: Opaque worker metadata, carried for parity with the
+                other rlinf families.
+            record_metrics: Whether to accumulate success/return metrics.
+        """
+        env_seed = cfg.seed
+        self.seed = env_seed + seed_offset
+        self.base_seed = env_seed
+        self.num_envs = num_envs
+        self.seed_offset = seed_offset
+        self.total_num_processes = total_num_processes
+        self.worker_info = worker_info
+        self.auto_reset = cfg.auto_reset
+        self.use_rel_reward = cfg.use_rel_reward
+        self.ignore_terminations = cfg.ignore_terminations
+
+        self.group_size = cfg.group_size
+        self.num_group = self.num_envs // self.group_size
+        self.use_fixed_reset_state_ids = cfg.use_fixed_reset_state_ids
+        self.use_custom_reward = cfg.use_custom_reward
+
+        self.video_cfg = _cfg_get(cfg, "video_cfg")
+
+        self.cfg = cfg
+        self.record_metrics = record_metrics
+        self._is_start = True
+
+        self.task_name = cfg.task_config.task_name
+
+        self.center_crop = _cfg_get(cfg, "center_crop", False)
+        self._init_reset_state_ids()
+
+        self._init_env()
+
+        self.prev_step_reward = torch.zeros(
+            self.num_envs, dtype=torch.float32, device=self.device
+        )
+        # Upstream only creates `_elapsed_steps` under `record_metrics`, yet
+        # `step`/`chunk_step` read it unconditionally. Always create it: the
+        # truncation check is not a metric.
+        self._elapsed_steps = torch.zeros(
+            self.num_envs, dtype=torch.long, device=self.device
+        )
+        if self.record_metrics:
+            self._init_metrics()
+
+    def _init_env(self):
+        """Start the RoboTwin subprocess vector env.
+
+        ``ASSETS_PATH`` must point at the **RoboTwin repository root**, not at
+        its ``assets/`` subdirectory: RoboTwin joins ``assets/...`` onto it
+        internally (``envs/utils/rand_create_cluttered_actor.py``). This is
+        undocumented upstream and gives a confusing ``.../assets/assets/...``
+        ``FileNotFoundError`` when set to the subdirectory.
+
+        That same root is also where the importable ``robotwin`` package lives,
+        so it is put on ``sys.path`` when the package is not already importable.
+        Upstream leaves this to the operator (RLinf's run scripts export
+        ``ROBOTWIN_PATH`` into ``PYTHONPATH``), which means one path has to be
+        configured twice and getting it wrong surfaces as a bare
+        ``ModuleNotFoundError`` several frames inside pool construction. The
+        config already knows the root; there is no reason to ask for it again.
+        """
+        ensure_spawn_start_method()
+        os.environ["ASSETS_PATH"] = self.cfg.assets_path
+        _ensure_robotwin_importable(self.cfg.assets_path)
+
+        from robotwin.envs.vector_env import VectorEnv
+
+        env_seeds = self.reset_state_ids.tolist()
+
+        self.venv = VectorEnv(
+            task_config=_as_container(self.cfg.task_config),
+            n_envs=self.num_envs,
+            env_seeds=env_seeds,
+        )
+
+    @property
+    def device(self):
+        """Device the metric/reward tensors live on.
+
+        Returns:
+            ``cuda`` when available, else ``cpu``. RoboTwin renders through
+            SAPIEN and therefore needs a GPU in practice, which is why the
+            family declares ``needs_accelerator_override=True``.
+        """
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    @property
+    def elapsed_steps(self):
+        """Per-lane step counter for the current episode.
+
+        Returns:
+            A ``[num_envs]`` long tensor.
+        """
+        return self._elapsed_steps
+
+    @property
+    def is_start(self):
+        """Whether no reset has happened yet.
+
+        Returns:
+            ``True`` until the first ``reset``.
+        """
+        return self._is_start
+
+    @is_start.setter
+    def is_start(self, value):
+        """Set the pre-first-reset flag.
+
+        Args:
+            value: The new flag value.
+        """
+        self._is_start = value
+
+    def _init_metrics(self):
+        """Allocate the success/return metric accumulators."""
+        self.success_once = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.bool
+        )
+        self.fail_once = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.bool
+        )
+        self.returns = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.float32
+        )
+
+    def _reset_metrics(self, env_idx=None):
+        """Clear metric state for some or all lanes.
+
+        Args:
+            env_idx: Lane indices to clear; ``None`` clears every lane.
+        """
+        if env_idx is not None:
+            mask = torch.zeros(self.num_envs, dtype=bool, device=self.device)
+            mask[env_idx] = True
+            self.prev_step_reward[mask] = 0.0
+            self._elapsed_steps[env_idx] = 0
+            if self.record_metrics:
+                self.success_once[mask] = False
+                self.fail_once[mask] = False
+                self.returns[mask] = 0
+        else:
+            self.prev_step_reward[:] = 0
+            self._elapsed_steps[:] = 0
+            if self.record_metrics:
+                self.success_once[:] = False
+                self.fail_once[:] = False
+                self.returns[:] = 0.0
+
+    def _record_metrics(self, step_reward, infos):
+        """Fold this step's reward and success flag into the episode metrics.
+
+        Args:
+            step_reward: Per-lane reward for the step just executed.
+            infos: The step's info dict; mutated to carry ``episode``.
+
+        Returns:
+            The same ``infos`` dict, with an ``episode`` sub-dict added.
+        """
+        episode_info = {}
+        self.returns += step_reward
+        if "success" in infos:
+            if isinstance(infos["success"], list):
+                infos["success"] = torch.as_tensor(
+                    np.array(infos["success"]).reshape(-1), device=self.device
+                )
+            self.success_once = self.success_once | infos["success"]
+            episode_info["success_once"] = self.success_once.clone()
+        episode_info["return"] = self.returns.clone()
+        episode_info["episode_len"] = self.elapsed_steps.clone()
+        episode_info["reward"] = episode_info["return"] / episode_info["episode_len"]
+        infos["episode"] = episode_info
+        return infos
+
+    def center_and_crop(self, image, center_crop=False):
+        """Normalise one raw camera frame to an RGB uint8 array.
+
+        Args:
+            image: Raw camera frame.
+            center_crop: Whether to apply the centre crop + resize to 224x224.
+
+        Returns:
+            An ``HxWx3`` uint8 array; ``(224, 224, 3)`` when ``center_crop``.
+        """
+        array = np.asarray(image)
+        if center_crop:
+            return center_crop_image(array)
+        from PIL import Image
+
+        return np.asarray(Image.fromarray(array).convert("RGB"))
+
+    def _extract_obs_image(self, raw_obs):
+        """Project RoboTwin's per-lane dicts onto the shared 4-key layout.
+
+        RoboTwin exposes three **separate** camera keys (``full_image``,
+        ``left_wrist_image``, ``right_wrist_image``); upstream stacks the two
+        wrists into a single ``[B, n, H, W, C]`` ``wrist_images`` tensor, with
+        ``n`` in ``{1, 2}``, or ``None`` when ``collect_wrist_camera`` is off.
+        That stacking is preserved here so this file stays diffable; the
+        Runtime adapter unstacks it again to fill ``Observation.wrist_image``
+        (left) and ``Observation.extra_view_images[0]`` (right).
+
+        Args:
+            raw_obs: List of per-lane observation dicts from ``venv``.
+
+        Returns:
+            Dict with ``main_images``, ``wrist_images``, ``states`` and
+            ``task_descriptions``.
+        """
+        batch_images = []
+        batch_wrist_images = []
+        batch_states = []
+        batch_instructions = []
+        wrist_names: list[str] = []
+        for obs in raw_obs:
+            batch_images.append(
+                self.center_and_crop(obs["full_image"], center_crop=self.center_crop)
+            )
+            wrist_images = []
+            wrist_names = []
+            if "left_wrist_image" in obs and obs["left_wrist_image"] is not None:
+                wrist_images.append(
+                    self.center_and_crop(
+                        obs["left_wrist_image"], center_crop=self.center_crop
+                    )
+                )
+                wrist_names.append("left_wrist_image")
+            if "right_wrist_image" in obs and obs["right_wrist_image"] is not None:
+                wrist_images.append(
+                    self.center_and_crop(
+                        obs["right_wrist_image"], center_crop=self.center_crop
+                    )
+                )
+                wrist_names.append("right_wrist_image")
+            if len(wrist_images) > 0:
+                batch_wrist_images.append(
+                    torch.stack([torch.from_numpy(img) for img in wrist_images])
+                )
+            batch_states.append(obs["state"])
+            batch_instructions.append(obs["instruction"])
+
+        batch_images = torch.stack([torch.from_numpy(img) for img in batch_images])
+        if len(batch_wrist_images) > 0:
+            batch_wrist_images = torch.stack(batch_wrist_images)
+        else:
+            batch_wrist_images = None
+        batch_states = torch.stack(
+            [torch.from_numpy(np.asarray(state)) for state in batch_states]
+        )
+
+        return {
+            "main_images": batch_images,
+            "wrist_images": batch_wrist_images,
+            "states": batch_states,
+            "task_descriptions": batch_instructions,
+            # Additive, Zetta-only: names the stacked wrist frames in order, so
+            # the Runtime adapter never has to guess that index 0 is the left
+            # wrist. Empty when `wrist_images` is None.
+            "wrist_image_names": list(wrist_names)
+            if batch_wrist_images is not None
+            else [],
+        }
+
+    def _calc_step_reward(self, terminations):
+        """Derive the custom reward from the termination flag.
+
+        Args:
+            terminations: Per-lane termination flags.
+
+        Returns:
+            Absolute reward, or its difference from the previous step when
+            ``use_rel_reward``.
+        """
+        reward = self.cfg.reward_coef * terminations
+
+        reward_diff = reward - self.prev_step_reward
+        self.prev_step_reward = reward
+
+        if self.use_rel_reward:
+            return reward_diff
+        else:
+            return reward
+
+    def _cal_chunk_rewards(self, step_reward, chunk_step, terminations, infos):
+        """Spread a chunk's single reward across the chunk's step slots.
+
+        RoboTwin only scores once per submitted chunk, so the reward lands on
+        the chunk's final slot. ``n_steps_to_run`` is pinned to zero upstream
+        (the real source is commented out there), which makes ``start_idx``
+        the last index; that behaviour is preserved.
+
+        Args:
+            step_reward: Per-lane reward for the chunk.
+            chunk_step: Number of actions submitted in the chunk.
+            terminations: Per-lane termination flags.
+            infos: The chunk's info dict (unused; kept for signature parity).
+
+        Returns:
+            A ``[num_envs, chunk_step]`` reward tensor.
+        """
+        n_steps_to_run = np.array([[0] for _ in range(self.num_envs)])
+
+        n_steps_to_run = torch.as_tensor(
+            np.array(n_steps_to_run).reshape(-1), device=self.device
+        )
+        chunk_rewards = torch.zeros(self.num_envs, chunk_step, device=self.device)
+        for env_id in range(self.num_envs):
+            steps_left = n_steps_to_run[env_id]
+            reward = step_reward[env_id]
+            start_idx = chunk_step - steps_left - 1
+
+            if terminations[env_id] and start_idx > 0:
+                if self.use_rel_reward:
+                    chunk_rewards[env_id, start_idx] = reward
+                else:
+                    chunk_rewards[env_id, start_idx:] = reward
+
+        return chunk_rewards
+
+    def reset(
+        self,
+        env_idx: Optional[Union[int, list[int]]] = None,
+        env_seeds=None,
+    ):
+        """Reset some or all lanes.
+
+        This is the ``env_idx_env_seeds`` reset signature declared for the
+        family in ``rollout_runtime/core/env_registry.py``.
+
+        Args:
+            env_idx: Lane indices to reset; ``None`` resets every lane.
+            env_seeds: Explicit seeds; ``None`` uses the current
+                ``reset_state_ids``.
+
+        Returns:
+            ``(extracted_obs, infos)``.
+        """
+        if self._is_start:
+            self._is_start = False
+
+        env_seeds = self.reset_state_ids.tolist() if env_seeds is None else env_seeds
+
+        self.venv.reset(env_idx=env_idx, env_seeds=env_seeds)
+        raw_obs = self.venv.get_obs()
+        infos = {}
+
+        self._reset_metrics(env_idx)
+
+        extracted_obs = self._extract_obs_image(raw_obs)
+
+        return extracted_obs, infos
+
+    def step(
+        self, actions: Union[torch.Tensor, np.ndarray, dict] = None, auto_reset=True
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, dict]:
+        """Advance every lane by the supplied actions.
+
+        Args:
+            actions: ``[num_envs, horizon, action_dim]`` (or
+                ``[num_envs, action_dim]``, which is promoted to horizon 1).
+            auto_reset: Whether to honour ``cfg.auto_reset`` for finished lanes.
+
+        Returns:
+            ``(extracted_obs, step_reward, terminations, truncations, infos)``.
+        """
+        if actions is None:
+            assert self._is_start, "Actions must be provided after the first reset."
+
+        if isinstance(actions, torch.Tensor):
+            actions = actions.cpu().numpy()
+        elif isinstance(actions, dict):
+            actions = actions.get("actions", actions)
+
+        # [n_envs, horizon, action_dim]
+        if len(actions.shape) == 2:
+            # [n_envs, action_dim] -> [n_envs, 1, action_dim]
+            actions = actions[:, None, :]
+
+        raw_obs, step_reward, terminations, truncations, info_list = self.venv.step(
+            actions
+        )
+        extracted_obs = self._extract_obs_image(raw_obs)
+        infos = list_of_dict_to_dict_of_list(info_list)
+
+        terminations, truncations = self._as_flag_tensors(terminations, truncations)
+        step_reward = self._resolve_step_reward(step_reward, terminations)
+
+        self._elapsed_steps += actions.shape[1]
+        truncations = self._apply_horizon_truncation(truncations)
+
+        infos = self._record_metrics(step_reward, infos)
+        terminations = self._apply_ignore_terminations(terminations, infos)
+
+        dones = torch.logical_or(terminations, truncations)
+
+        _auto_reset = auto_reset and self.auto_reset
+        if dones.any() and _auto_reset:
+            extracted_obs, infos = self._handle_auto_reset(dones, extracted_obs, infos)
+
+        return extracted_obs, step_reward, terminations, truncations, infos
+
+    def chunk_step(self, chunk_actions):
+        """Submit a whole action chunk and observe **only the final frame**.
+
+        This is the ``final_only`` behaviour: one ``venv.step`` call for the
+        entire chunk, so ``obs_list`` has length 1 no matter how long the chunk
+        is. Reward/termination tensors are chunk-shaped but only their last
+        column is populated.
+
+        Args:
+            chunk_actions: ``[num_envs, chunk_step, action_dim]``.
+
+        Returns:
+            ``(obs_list, chunk_rewards, chunk_terminations, chunk_truncations,
+            infos_list)``, where ``obs_list`` and ``infos_list`` both have
+            length 1.
+        """
+        if isinstance(chunk_actions, torch.Tensor):
+            chunk_actions = chunk_actions.cpu().numpy()
+
+        # chunk_actions: [num_envs, chunk_step, action_dim]
+        num_envs = chunk_actions.shape[0]
+        chunk_step = chunk_actions.shape[1]
+        obs_list = []
+        infos_list = []
+
+        raw_obs, step_reward, terminations, truncations, info_list = self.venv.step(
+            chunk_actions
+        )
+        extracted_obs = self._extract_obs_image(raw_obs)
+        infos = list_of_dict_to_dict_of_list(info_list)
+        obs_list.append(extracted_obs)
+        infos_list.append(infos)
+
+        terminations, truncations = self._as_flag_tensors(terminations, truncations)
+        step_reward = self._resolve_step_reward(step_reward, terminations)
+
+        chunk_rewards = self._cal_chunk_rewards(
+            step_reward, chunk_step, terminations, infos
+        )
+
+        self._elapsed_steps += chunk_actions.shape[1]
+        truncations = self._apply_horizon_truncation(truncations)
+
+        infos = self._record_metrics(step_reward, infos)
+        terminations = self._apply_ignore_terminations(terminations, infos)
+
+        past_dones = torch.logical_or(terminations, truncations)
+        if past_dones.any() and self.auto_reset:
+            obs_list[-1], infos_list[-1] = self._handle_auto_reset(
+                past_dones, obs_list[-1], infos_list[-1]
+            )
+
+        chunk_terminations = torch.zeros((num_envs, chunk_step), dtype=bool)
+        chunk_terminations[:, -1] = terminations
+
+        chunk_truncations = torch.zeros((num_envs, chunk_step), dtype=bool)
+        chunk_truncations[:, -1] = truncations
+
+        return (
+            obs_list,
+            chunk_rewards,
+            chunk_terminations,
+            chunk_truncations,
+            infos_list,
+        )
+
+    def _as_flag_tensors(self, terminations, truncations):
+        """Normalise the venv's list-or-tensor flags into device tensors.
+
+        Args:
+            terminations: Per-lane termination flags.
+            truncations: Per-lane truncation flags.
+
+        Returns:
+            The pair, both as tensors on ``self.device``.
+        """
+        if isinstance(terminations, list):
+            terminations = torch.as_tensor(
+                np.array(terminations).reshape(-1), device=self.device
+            )
+        if isinstance(truncations, list):
+            truncations = torch.as_tensor(
+                np.array(truncations).reshape(-1), device=self.device
+            )
+        return terminations, truncations
+
+    def _resolve_step_reward(self, step_reward, terminations):
+        """Pick between the custom reward and the environment's own.
+
+        Args:
+            step_reward: The venv's reward.
+            terminations: Per-lane termination flags.
+
+        Returns:
+            The reward tensor to record.
+        """
+        if self.use_custom_reward:
+            return self._calc_step_reward(terminations)
+        if isinstance(step_reward, list):
+            return torch.as_tensor(
+                np.array(step_reward, dtype=np.float32).reshape(-1),
+                device=self.device,
+            )
+        return step_reward
+
+    def _apply_horizon_truncation(self, truncations):
+        """OR in the truncation implied by ``max_episode_steps``.
+
+        Args:
+            truncations: Per-lane truncation flags.
+
+        Returns:
+            The updated truncation flags.
+        """
+        truncated = self._elapsed_steps >= self.cfg.max_episode_steps
+        if truncated.any():
+            truncations = torch.logical_or(truncated, truncations)
+        return truncations
+
+    def _apply_ignore_terminations(self, terminations, infos):
+        """Zero the termination flags when the config asks for fixed horizons.
+
+        Args:
+            terminations: Per-lane termination flags.
+            infos: Info dict; gains ``episode.success_at_end`` when metrics are
+                recorded.
+
+        Returns:
+            The updated termination flags.
+        """
+        if self.ignore_terminations:
+            terminations[:] = False
+            if self.record_metrics and "success" in infos:
+                infos["episode"]["success_at_end"] = infos["success"].clone()
+        return terminations
+
+    def _handle_auto_reset(self, dones, extracted_obs, infos):
+        """Reset finished lanes and stash their final frame in ``infos``.
+
+        Args:
+            dones: Per-lane done flags.
+            extracted_obs: The observation about to be replaced.
+            infos: The current info dict.
+
+        Returns:
+            ``(post_reset_obs, infos)`` where ``infos`` carries
+            ``final_observation``/``final_info``.
+        """
+        final_obs = extracted_obs.copy()
+        env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
+        final_info = infos.copy()
+        if self.cfg.is_eval:
+            self.update_reset_state_ids(env_idx=env_idx)
+
+        extracted_obs, infos = self.reset(env_idx=env_idx.tolist())
+        # gymnasium calls it final observation but it really is just o_{t+1} or
+        # the true next observation
+        infos["final_observation"] = final_obs
+        infos["final_info"] = final_info
+        infos["_final_info"] = dones
+        infos["_final_observation"] = dones
+        infos["_elapsed_steps"] = dones
+        return extracted_obs, infos
+
+    def offload(self, clear_cache=True):
+        """Close the subprocess vector env, if one was built.
+
+        Args:
+            clear_cache: Forwarded to ``VectorEnv.close``.
+        """
+        if hasattr(self, "venv"):
+            self.venv.close(clear_cache)
+
+    def _load_success_seeds(self):
+        """Read the curated success-seed list for this task, if configured.
+
+        Returns:
+            The seed tensor for this worker, or ``None`` when no usable
+            ``seeds_path`` is configured.
+        """
+        seeds_path = _cfg_get(self.cfg, "seeds_path", None)
+        if seeds_path is None or not os.path.exists(seeds_path):
+            return None
+        with open(seeds_path, "r") as handle:
+            data = json.load(handle)
+        success_seeds = data[self.task_name].get("success_seeds", None)
+        if success_seeds is None:
+            return None
+        return partition_success_seeds(
+            torch.as_tensor(success_seeds, dtype=torch.long),
+            base_seed=self.base_seed,
+            seed_offset=self.seed_offset,
+            total_num_processes=self.total_num_processes,
+            num_group=self.num_group,
+        )
+
+    def _init_reset_state_ids(self):
+        """Seed the reset-state schedule from the success-seed list or the RNG."""
+        self.success_seeds = self._load_success_seeds()
+        self._current_seed_index = 0
+
+        if not hasattr(self, "_generator"):
+            self._generator = torch.Generator()
+            self._generator.manual_seed(self.seed)
+        self.update_reset_state_ids()
+
+    def _next_reset_state_ids(self):
+        """Draw the next round of per-group reset seeds.
+
+        Returns:
+            A ``[num_envs]`` seed tensor (each group's seed repeated
+            ``group_size`` times).
+        """
+        if self.success_seeds is not None:
+            total_seeds = self.success_seeds.numel()
+            indices = (
+                torch.arange(self.num_group, device=self.success_seeds.device)
+                + self._current_seed_index
+            ) % total_seeds
+            reset_state_ids = self.success_seeds[indices]
+            self._current_seed_index = (
+                self._current_seed_index + self.num_group
+            ) % total_seeds
+        else:
+            reset_state_ids = torch.randint(
+                low=10000,
+                high=200000,
+                size=(self.num_group,),
+                generator=self._generator,
+            )
+        return reset_state_ids.repeat_interleave(repeats=self.group_size)
+
+    def update_reset_state_ids(self, env_idx=None):
+        """Advance the reset-state schedule.
+
+        A no-op once ``use_fixed_reset_state_ids`` is set and a schedule
+        already exists -- that is how an eval run keeps every episode on the
+        same seed set.
+
+        Args:
+            env_idx: Lane indices to refresh; ``None`` refreshes all.
+        """
+        if self.use_fixed_reset_state_ids and hasattr(self, "reset_state_ids"):
+            return
+
+        reset_state_ids = self._next_reset_state_ids()
+
+        if env_idx is not None and hasattr(self, "reset_state_ids"):
+            for idx in env_idx:
+                self.reset_state_ids[idx] = reset_state_ids[idx]
+        else:
+            self.reset_state_ids = reset_state_ids
+
+    def check_seeds(self, seeds):
+        """Ask the vector env which of ``seeds`` are usable.
+
+        Args:
+            seeds: Candidate seeds.
+
+        Returns:
+            The vector env's per-seed result.
+        """
+        return self.venv.check_seeds(seeds)

--- a/zetta/envs/robotwin/utils.py
+++ b/zetta/envs/robotwin/utils.py
@@ -1,0 +1,171 @@
+"""Helpers for the RoboTwin environment, derived from RLinf.
+
+Two pieces are adapted rather than copied verbatim:
+
+- :func:`center_crop_image` replaces RLinf's TensorFlow implementation
+  (``rlinf/envs/utils.py``) with a NumPy/Pillow one. The upstream helper pulls
+  in ``tensorflow`` purely to call ``tf.image.crop_and_resize`` on a single
+  frame; TensorFlow is not a Zetta dependency and adding it for one bilinear
+  resample is not worth a multi-hundred-megabyte wheel.
+- :func:`ensure_spawn_start_method` wraps the bare
+  ``mp.set_start_method("spawn", force=True)`` that upstream executes as an
+  import-time-ish side effect inside ``RoboTwinEnv._init_env``.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "center_crop_image",
+    "ensure_spawn_start_method",
+    "partition_success_seeds",
+]
+
+CROP_SCALE = 0.9
+"""Fraction of the **original image area** kept by the centre crop.
+
+Matches RLinf's ``crop_and_resize`` default. The linear crop fraction is
+``sqrt(CROP_SCALE)``, applied to both axes.
+"""
+
+CROP_OUTPUT_SIZE = (224, 224)
+"""Size the crop is resampled to, matching RLinf's hard-coded ``(224, 224)``.
+
+RoboTwin's cameras deliver 240x320 frames, so this step is also what brings a
+raw observation to the resolution the Pi0/Pi0.5 image transforms expect.
+"""
+
+
+def center_crop_image(
+    image: Any,
+    *,
+    crop_scale: float = CROP_SCALE,
+    output_size: tuple[int, int] = CROP_OUTPUT_SIZE,
+) -> np.ndarray:
+    """Centre-crop to ``crop_scale`` of the original area, then resize.
+
+    Mirrors ``rlinf.envs.utils.center_crop_image`` -> ``crop_and_resize``: crop
+    a centred box covering ``crop_scale`` of the area (so ``sqrt(crop_scale)``
+    of each side) and bilinearly resample it to ``output_size``. Upstream
+    round-trips through float32 inside TensorFlow and saturates back to uint8;
+    Pillow's bilinear resize on uint8 is numerically very close and avoids the
+    dependency. The contract that matters downstream -- output shape, dtype and
+    channel count -- is identical.
+
+    Args:
+        image: An ``HxWx3`` uint8 array, or anything ``np.asarray`` accepts.
+        crop_scale: Fraction of the original area to keep, clamped to
+            ``[0, 1]``.
+        output_size: ``(width, height)`` of the resampled result.
+
+    Returns:
+        An ``output_size`` uint8 RGB array.
+
+    Raises:
+        ValueError: The input does not have a height and a width.
+    """
+    from PIL import Image
+
+    array = np.asarray(image)
+    if array.ndim < 2:
+        raise ValueError(
+            f"center_crop_image expects an image with H and W, got shape {array.shape}"
+        )
+
+    height, width = array.shape[:2]
+    fraction = math.sqrt(min(max(float(crop_scale), 0.0), 1.0))
+    crop_h = max(1, int(round(height * fraction)))
+    crop_w = max(1, int(round(width * fraction)))
+    top = (height - crop_h) // 2
+    left = (width - crop_w) // 2
+    cropped = array[top : top + crop_h, left : left + crop_w]
+
+    picture = Image.fromarray(np.ascontiguousarray(cropped)).convert("RGB")
+    return np.asarray(picture.resize(output_size, Image.BILINEAR))
+
+
+def ensure_spawn_start_method() -> str:
+    """Make the multiprocessing start method ``spawn``, idempotently.
+
+    RoboTwin's ``VectorEnv`` runs each lane in its own process and requires the
+    ``spawn`` start method; upstream therefore calls
+    ``mp.set_start_method("spawn", force=True)`` unconditionally inside
+    ``_init_env``. That is a **process-global** side effect: under the Rollout
+    Runtime the env core is built inside a Ray worker that has already made its
+    own multiprocessing choices, and silently forcing a different method there
+    is exactly the kind of action-at-a-distance that is painful to debug.
+
+    So the force is kept -- RoboTwin genuinely does not work without it -- but
+    it becomes explicit, idempotent, and loud when it actually changes
+    something.
+
+    Returns:
+        The start method in effect after the call (always ``"spawn"``).
+
+    Warns:
+        UserWarning: A different start method was already active and has been
+            overridden.
+    """
+    import torch.multiprocessing as mp
+
+    current = mp.get_start_method(allow_none=True)
+    if current == "spawn":
+        return "spawn"
+    if current is not None:
+        warnings.warn(
+            f"RoboTwin requires the 'spawn' multiprocessing start method; "
+            f"overriding the process-global start method {current!r}. "
+            "Anything else in this process that depends on "
+            f"{current!r} will be affected.",
+            UserWarning,
+            stacklevel=2,
+        )
+    mp.set_start_method("spawn", force=True)
+    return "spawn"
+
+
+def partition_success_seeds(
+    success_seeds,
+    *,
+    base_seed: int,
+    seed_offset: int,
+    total_num_processes: int,
+    num_group: int,
+):
+    """Shuffle the curated success seeds and return this worker's slice.
+
+    Copied from ``rlinf/envs/robotwin/seed_utils.py``. The shuffle is driven by
+    ``base_seed`` alone, so every worker derives the *same* global permutation
+    and then takes a disjoint contiguous slice of it -- that is what keeps the
+    per-worker seed sets non-overlapping without any coordination.
+
+    Args:
+        success_seeds: 1-D tensor of seeds known to be solvable for the task.
+        base_seed: Seed of the global permutation; must be identical across
+            workers.
+        seed_offset: This worker's index.
+        total_num_processes: Number of workers sharing the seed pool.
+        num_group: Group size the slice length is truncated to a multiple of.
+
+    Returns:
+        This worker's seed slice, truncated to a whole number of groups.
+    """
+    import torch
+
+    global_generator = torch.Generator()
+    global_generator.manual_seed(base_seed)
+    shuffled_indices = torch.randperm(success_seeds.numel(), generator=global_generator)
+    shuffled_seeds = success_seeds[shuffled_indices]
+
+    seeds_per_worker = shuffled_seeds.numel() // total_num_processes
+    start = seed_offset * seeds_per_worker
+    end = start + seeds_per_worker
+    worker_seeds = shuffled_seeds[start:end]
+
+    keep_count = (worker_seeds.numel() // num_group) * num_group
+    return worker_seeds[:keep_count]

--- a/zetta/evolution/lifecycle.py
+++ b/zetta/evolution/lifecycle.py
@@ -1570,7 +1570,7 @@ def _active_stage1_context(store: CampaignStore) -> dict[str, Any]:
                 )
                 if accepted_path.is_file() and canonical_sha256(
                     read_json(accepted_path)
-                ) != canonical_sha256(output):
+                ) != canonical_sha256(_normalized_stage1_output(output)):
                     raise ValueError("Stage1 output differs from accepted diagnosis")
         return context
     return {}
@@ -3373,6 +3373,35 @@ def _advance_after_candidate_rejection(
         "candidate_round": len(rejected),
         "optimization_outcome": "no_candidate_passed_primary_or_secondary",
     }
+
+
+def _normalized_stage1_output(output: dict[str, Any]) -> dict[str, Any]:
+    """Put a raw Stage1 output into the shape the accepted diagnosis is stored in.
+
+    ``output.json`` is the planner's raw JSON (``stages.py`` writes
+    ``_extract_json_object`` verbatim), while the accepted diagnosis is
+    ``CausalDiagnosis.as_dict()``, which drops ``visual_evidence`` and
+    ``task_contract`` when they hold their defaults so historical digests stay
+    stable.  Digesting the two directly therefore diverges whenever the model
+    spells out a default-valued field: a real campaign emitted
+    ``"task_contract": {}``, every other field matched byte for byte, and the run
+    stalled at PROPOSE with the diagnosis already accepted and written.
+
+    Normalising through the model preserves the invariant -- a semantic
+    difference in any field still mismatches -- without letting that spelling
+    decide the outcome.
+    """
+
+    try:
+        return _diagnosis(output).as_dict()
+    except (TypeError, ValueError) as exc:
+        # An output that cannot form a diagnosis at all cannot be the one that
+        # was accepted; surface it as the mismatch it is, not as a TypeError
+        # escaping from a consistency check.
+        raise ValueError(
+            "Stage1 output differs from accepted diagnosis: the recorded output "
+            f"is not a valid diagnosis ({exc})"
+        ) from exc
 
 
 def _diagnosis(value: dict[str, Any]) -> CausalDiagnosis:


### PR DESCRIPTION
Adds RoboTwin 2.0 as a Rollout Runtime environment family, together with the
Pi0.5 policy path, the Critic / Role1 / Recovery runtime, campaign preparation,
and a Codex stage preflight. The evolution loop runs end to end on hardware.

## What this adds

| Area | Files |
|---|---|
| Env family | `rollout_runtime/backends/rlinf_robotwin.py`, `core/env_registry.py`, preset `robotwin_pi05.yaml` |
| Vendored environment | `zetta/envs/robotwin/` (from RLinf `9ad44393`, with the deviations documented in-file) |
| Robot runtime | `robots/robotwin/` — action contract, tool catalog and bindings, Critic features, recovery controller, Role1 actor and model-backed agent, rollout driver |
| Campaign | `scripts/evolution/prepare_robotwin_campaign.py` |
| Stage preflight | `scripts/evolution/preflight_codex_stage.sh` |
| Visualization | `scripts/deployment/visualize_robotwin_episode.py` |

38 files, ~11.7k insertions. 175 new RoboTwin tests across 10 files, none of
which require a simulator or a model.

## Verified on hardware (8x RTX 4090)

| Stage | Result |
|---|---|
| Pure-VLA rollout | `adjust_bottle` success_once **0.9375** at `execute_horizon=50`, matching the RLinf native baseline exactly |
| Episode artifacts through the HTTP Runtime | 4 trajectory JSONL + 3 camera videos + visual evidence |
| Cluster → Diagnose | Diagnosis localises the failure to the policy's grasp-phase gripper channel (`owner_layer=vla`, confidence 0.82) |
| Stage 2 → same-seed gate → decision → Stage 2 | 5 candidate rounds, 22 gate rollouts, 0 failed, 4 conclusive decisions |
| Campaign terminal state | `complete` / `no_candidate_passed_primary_or_secondary` |

Stage 2's five candidates were a real hypothesis search rather than a retry loop:
the Critic dwell tightened 32 → 28 → 20 to walk the trigger toward the contact
moment, and two candidates switched to the competing branch the diagnosis itself
named, handing the remaining horizon back to the policy instead of forcing the
gripper closed.

## Engineering results

**`execute_horizon: 25` is measured, not assumed.** RoboTwin is the only
`final_only` family — one observation per chunk — so at horizon 50 a 50-step
episode yields 4 evidence rows, which is too coarse for causal attribution.
Measured over 16 eval seeds:

| `execute_horizon` | success_once | evidence rows / episode |
|---|---|---|
| 50 | 0.9375 | 4 |
| 25 | 0.875 | 8 |
| 16 | 0.75 | 13 |

The intuition that more frequent replanning also raises success does not hold for
this policy: Pi0.5 generates coherent 50-step trajectories and its SFT data is
executed whole, so interrupting mid-chunk leaves the training distribution. 25
buys double the evidence density for a difference that is not significant at
n=16.

**One feature vocabulary, guaranteed by construction.** `states.jsonl` publishes
runtime Critic feature names through `robotwin_state_features()`, shared with
`extract_robotwin_critic_features`. `lifecycle._observed_critic_features` turns
those keys into the vocabulary Stage 2 binds to, so the publisher and the
evaluator cannot name the same quantity differently. Chunk-delta features are
deliberately withheld from the per-step timeline, and a test asserts every
published name is one the runtime Critic can resolve.

**Evidence density without a fabricated progress signal.** `--capture-frames`
raises the state timeline and the video to per-simulator-step resolution;
chunked and stepwise submission were verified to produce bit-identical joint
states, so this changes observation density and not physics. `states.jsonl`
publishes none of the names `trajectory._window_no_progress` keys off, because
RoboTwin exposes no task-grounded progress scalar without privileged simulator
state and this family declares none.

**Curated seeds with recorded provenance.** RoboTwin picks its scene from the
seed outright, so the campaign draws from RoboTwin's per-task success-seed list
rather than a dense integer range. The protocol shape is unchanged — 20 fixed,
disjoint, pre-development held-out seeds — and the provenance is written into
both the manifest and the preregistration.

**Codex stage preflight.** `preflight_codex_stage.sh` checks the interpreter and
packages, the CLI binary, the credential route, the gateway's Responses-API
support, the loopback MCP transport, the sandbox, and one live nonce turn — all
seven reported together, so a stage runtime is validated for the price of a
single API call instead of a spent rollout budget.

**Shared Stage 1 fix.** `zetta/evolution/lifecycle.py` gains
`_normalized_stage1_output()`. `_active_stage1_context` was digesting the
planner's raw `output.json` against the accepted diagnosis, which is
`CausalDiagnosis.as_dict()` and drops fields holding their defaults; a planner
that spelled out `"task_contract": {}` therefore mismatched on an otherwise
byte-identical diagnosis. Normalising through the model keeps the invariant — a
semantic difference in any field still mismatches — and the change applies to
LIBERO and RoboCasa as well. Three regression tests.