### PR TITLE
fix(runtime): improve synchronous batch dispatch

### DIFF
--- a/rollout_runtime/workers/rollout_worker.py
+++ b/rollout_runtime/workers/rollout_worker.py
@@ -13,7 +13,7 @@ The M3 shape (M2 only wired things together, without batching):
 | ``init_worker`` / ``infer_batch`` / ``send_responses`` | Same as M2 |
 | ``serve`` | Two persistent loops: ``receive_requests`` ‖ ``execute_batches`` |
 | ``receive_requests`` | Competitively get from ``rr_infer_req["pending"]`` → record ``routing_token`` → **enqueue into the scheduler** |
-| ``execute_batches`` | Pull a batch bucketed by ``compat_key`` (``max_batch_size`` / ``max_wait_ms`` / priority / tenant fairness), one task per batch |
+| ``execute_batches`` | Pull a batch bucketed by ``compat_key`` (``max_batch_size`` / ``max_wait_ms`` / priority / tenant fairness); local synchronous cores execute one batch at a time, while truly asynchronous cores may overlap batches |
 | ``update_weights`` | The scheduler's version fence: raise fence → wait for in-flight to drain → swap weights → lower fence |
 
 Fetching is constrained by **two gates**; once either is saturated, no more requests
@@ -218,7 +218,12 @@ class RuntimeRolloutWorker:
         No polling: ``scheduler.time_until_ready`` gives the due time for the next
         batch, and the loop waits exactly that long (or until woken by a new
         request), so ``max_wait_ms`` is a genuine batch-accumulation window rather
-        than a sampling period.
+        than a sampling period. Synchronous policy cores are local compute
+        backends executed through ``asyncio.to_thread``. Only one such batch is
+        dispatched at a time: while it owns the accelerator, newly received
+        requests remain mergeable in the scheduler instead of becoming a queue of
+        immutable micro-batches. Cores exposing native ``ainfer_batch`` retain
+        concurrent dispatch for cancellable remote/asynchronous inference.
 
         Args:
             response_channel: The ``rr_infer_resp`` channel.
@@ -227,7 +232,13 @@ class RuntimeRolloutWorker:
         while self._serving:
             batch = self.scheduler.next_batch(loop.time())
             if batch:
-                self._spawn(self._run_batch(batch, response_channel))
+                sync_core = getattr(self.policy, "ainfer_batch", None) is None
+                inference_done = asyncio.Event() if sync_core else None
+                self._spawn(
+                    self._run_batch(batch, response_channel, inference_done)
+                )
+                if inference_done is not None:
+                    await inference_done.wait()
                 continue
             self._wake.clear()
             delay = self.scheduler.time_until_ready(loop.time())
@@ -251,13 +262,17 @@ class RuntimeRolloutWorker:
             with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
                 await asyncio.wait_for(self._wake.wait(), delay)
 
-    def _spawn(self, coroutine: Any) -> None:
+    def _spawn(self, coroutine: Any) -> asyncio.Task[None]:
         task = asyncio.get_running_loop().create_task(coroutine)
         self._tasks.add(task)
         task.add_done_callback(self._finish_task)
+        return task
 
     async def _run_batch(
-        self, batch: list[PendingRequest], response_channel: Any
+        self,
+        batch: list[PendingRequest],
+        response_channel: Any,
+        inference_done: asyncio.Event | None = None,
     ) -> None:
         """Execute one batch and send responses (total function).
 
@@ -267,11 +282,17 @@ class RuntimeRolloutWorker:
         """
         requests = [pending.request for pending in batch]
         try:
-            responses = await self.infer_batch(requests)
-        except asyncio.CancelledError:
-            raise
-        except BaseException as exc:  # noqa: BLE001 - must never leak
-            responses = [self._failed_response(request, exc) for request in requests]
+            try:
+                responses = await self.infer_batch(requests)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:  # noqa: BLE001 - must never leak
+                responses = [
+                    self._failed_response(request, exc) for request in requests
+                ]
+        finally:
+            if inference_done is not None:
+                inference_done.set()
         try:
             await self.send_responses(responses, response_channel)
         except asyncio.CancelledError:

--- a/tests/runtime/test_batch_scheduler.py
+++ b/tests/runtime/test_batch_scheduler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import threading
 from typing import Any
 
 import pytest
@@ -36,6 +37,41 @@ from rollout_runtime.workers.rollout_worker import RuntimeRolloutWorker
 
 ROUTE = make_routing_token("env", 0)
 """Response routing token shared by all test cases."""
+
+
+class _BlockingSyncPolicy(FakePolicyCore):
+    """Synchronous single-device core whose batches stay blocked until released."""
+
+    ainfer_batch = None
+
+    def __init__(self) -> None:
+        super().__init__(FakePolicyConfig())
+        self.started_batch_sizes: list[int] = []
+        self.first_batch_started = threading.Event()
+        self.release_batches = threading.Event()
+        self._record_lock = threading.Lock()
+
+    def infer_batch(self, requests: list[InferenceRequest]) -> Any:
+        with self._record_lock:
+            self.started_batch_sizes.append(len(requests))
+            self.first_batch_started.set()
+        if not self.release_batches.wait(timeout=5.0):
+            raise TimeoutError("test did not release the blocked inference batch")
+        return super().infer_batch(requests)
+
+
+class _BlockedResponseChannel(InProcInferenceChannel):
+    """Hold response delivery so the test can observe the inference gate."""
+
+    def __init__(self) -> None:
+        super().__init__(request_queue_size=32, response_queue_size=32)
+        self.response_started = asyncio.Event()
+        self.release_responses = asyncio.Event()
+
+    async def put_response_nowait(self, routing_token: str, response: Any) -> None:
+        self.response_started.set()
+        await self.release_responses.wait()
+        await super().put_response_nowait(routing_token, response)
 
 
 def make_pending(
@@ -395,6 +431,122 @@ async def test_execute_batches_really_coalesces() -> None:
         assert worker.scheduler.batch_count <= 4, "requests were not coalesced at all"
         assert policy.batch_calls == worker.scheduler.batch_count
     finally:
+        await worker.stop()
+        channel.close()
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+
+
+async def test_busy_sync_policy_keeps_next_batch_mergeable() -> None:
+    """A local accelerator must finish its active batch before freezing the next.
+
+    The first batch is held inside a synchronous policy core while eight more
+    compatible requests arrive. They must remain queued as one mergeable batch,
+    rather than entering eight concurrent ``to_thread`` calls.
+    """
+    channel = InProcInferenceChannel(request_queue_size=32, response_queue_size=32)
+    policy = _BlockingSyncPolicy()
+    worker = RuntimeRolloutWorker(
+        policy=policy,
+        scheduler_config=SchedulerConfig(
+            max_batch_size=8,
+            max_wait_ms=10.0,
+            max_inflight_per_application=32,
+            max_inflight_per_session=1,
+        ),
+        max_concurrent_inferences=16,
+    )
+    channel.register_route(ROUTE)
+    task = await _serve(worker, channel)
+    try:
+        await channel.put_request_nowait(
+            make_pending(session_id="active", step_index=0).request
+        )
+        assert await asyncio.to_thread(policy.first_batch_started.wait, 1.0)
+
+        for index in range(8):
+            await channel.put_request_nowait(
+                make_pending(session_id=f"queued-{index}", step_index=index + 1).request
+            )
+        for _ in range(200):
+            if worker.received_count == 9:
+                break
+            await asyncio.sleep(0.005)
+        assert worker.received_count == 9
+
+        # Wait beyond max_wait_ms. A second synchronous batch must not have been
+        # removed from the scheduler while the first one still owns the device.
+        await asyncio.sleep(0.025)
+        assert policy.started_batch_sizes == [1]
+        assert worker.scheduler.batch_count == 1
+        assert worker.scheduler.queue_depth == 8
+        assert worker.inflight == 1
+
+        policy.release_batches.set()
+        for _ in range(200):
+            if worker.responded_count == 9:
+                break
+            await asyncio.sleep(0.005)
+        assert worker.responded_count == 9
+        assert policy.started_batch_sizes == [1, 8]
+        assert worker.scheduler.batch_count == 2
+    finally:
+        policy.release_batches.set()
+        await worker.stop()
+        channel.close()
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+
+
+async def test_sync_inference_gate_does_not_wait_for_response_delivery() -> None:
+    """Slow response I/O may overlap the next batch, but sync inference may not."""
+    channel = _BlockedResponseChannel()
+    policy = _BlockingSyncPolicy()
+    policy.release_batches.set()
+    worker = RuntimeRolloutWorker(
+        policy=policy,
+        scheduler_config=SchedulerConfig(
+            max_batch_size=2,
+            max_wait_ms=50.0,
+            max_inflight_per_application=32,
+            max_inflight_per_session=1,
+        ),
+        max_concurrent_inferences=16,
+    )
+    channel.register_route(ROUTE)
+    task = await _serve(worker, channel)
+    try:
+        for index in range(4):
+            await channel.put_request_nowait(
+                make_pending(
+                    session_id=f"response-gate-{index}", step_index=index
+                ).request
+            )
+
+        await asyncio.wait_for(channel.response_started.wait(), timeout=1.0)
+        for _ in range(200):
+            with policy._record_lock:
+                started = list(policy.started_batch_sizes)
+            if len(started) == 2:
+                break
+            await asyncio.sleep(0.005)
+
+        # The GPU-side calls remain sequential, but response delivery from batch 1
+        # does not prevent the second batch from entering synchronous inference.
+        assert started == [2, 2]
+        assert worker.scheduler.batch_count == 2
+
+        channel.release_responses.set()
+        for _ in range(200):
+            if worker.responded_count == 4:
+                break
+            await asyncio.sleep(0.005)
+        assert worker.responded_count == 4
+    finally:
+        channel.release_responses.set()
+        policy.release_batches.set()
         await worker.stop()
         channel.close()
         task.cancel()


### PR DESCRIPTION
## Summary

Fixes #13 by preventing multiple synchronous inference batches from being dispatched concurrently to the same GPU.

Requests arriving while the GPU is busy now remain in the scheduler and can be merged into a larger next batch. The dispatch gate is released immediately after inference, allowing response delivery to overlap with the next GPU forward.

Native asynchronous `ainfer_batch()` behavior is unchanged.

## Validation

Test environment:

- 8 × RTX 4090 host
- Pi0.5 VLA
- Real Ray + LIBERO
- GPU 7 for inference, GPU 6 for rendering
- `max_batch_size=16`, `max_wait_ms=50`
- Requests staggered by approximately 25 ms

| Concurrency | Batches | Average BS | Throughput |
|---:|---:|---:|---:|
| 16 | 42 → 29 | 3.81 → 5.52 | 6.77 → 12.69 steps/s |
| 32 | 106 → 21 | 3.02 → 15.24 | 6.29 → 16.96 steps/s |
| 48 | 138 → 31 | 3.48 → 15.48 | 7.10 → 16.52 steps/s |

A 48-request Pi0.5 stress test reduced the number of inference batches from 21 to 5 and increased throughput from 8.47 to 16.63 req/s.

Tests also confirm that response delivery can overlap with the next inference batch without allowing concurrent synchronous GPU forwards.

## Conclusion

The issue is reproducible at high concurrency. This fix substantially increases batch size, GPU utilization, and throughput while reducing latency. All tested requests completed successfully with no dropped responses or OOM errors.

At low concurrency, partial batches may still wait up to `max_wait_ms`, which remains a configurable batching trade-off.