### PR TITLE
fix(runtime): avoid GPU re-reservation on warm reset

### DIFF
--- a/rollout_runtime/backends/rlinf_env.py
+++ b/rollout_runtime/backends/rlinf_env.py
@@ -38,6 +38,7 @@ the simulator dependency kept as a lazy import inside functions.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import os
 import threading
@@ -83,6 +84,7 @@ from rollout_runtime.core.env_registry import (
     register_env_family,
     requested_core_form,
 )
+from zetta.utils.gpu_memory_guard import GpuMemoryExhausted, reserve_gpu_memory
 
 __all__ = [
     "LIBERO_ENV_FAMILY",
@@ -175,6 +177,10 @@ class LiberoEnvConfig:
             explanation.
         assets_root: Override for the robosuite assets root directory;
             ``None`` means no override.
+        gpu_memory_reserve_mib: Estimated transient GPU allocation for one
+            LIBERO scene's first reset. The process-local GPU guard uses it
+            to prevent concurrent native allocations from overcommitting a
+            device. Zero disables the guard.
     """
 
     task_suite_name: str = "libero_10"
@@ -206,6 +212,7 @@ class LiberoEnvConfig:
     core_form: str = PER_SLOT_FORM
 
     assets_root: str | None = None
+    gpu_memory_reserve_mib: int = 800
 
     @classmethod
     def from_mapping(cls, config: Mapping[str, Any] | None) -> LiberoEnvConfig:
@@ -465,6 +472,9 @@ class _LiberoSlot:
         audit_trace: The per-step audit record accumulated across chunks
             (matching the legacy ``_audit_trace``, read by the
             ``libero.audit_trace`` extension method).
+        gpu_scene_ready: Whether this slot has completed its first reset and
+            therefore already owns its EGL/MuJoCo scene allocation. Warm
+            episode-boundary resets must not reserve that memory again.
     """
 
     env: Any
@@ -491,6 +501,7 @@ class _LiberoSlot:
     critic_previous_eef: np.ndarray | None = None
     critic_history_pending_reset: bool = True
     audit_trace: list[dict[str, Any]] = dataclasses.field(default_factory=list)
+    gpu_scene_ready: bool = False
 
 
 class LiberoEnvCore:
@@ -526,6 +537,9 @@ class LiberoEnvCore:
         # Vector form: whether the whole pool has already been fully
         # initialized once (the first reset must cover every lane).
         self._vector_initialized = False
+        # A vector pool owns one shared native scene allocation, so its GPU
+        # reservation lifecycle is pool-wide rather than per lane.
+        self._vector_gpu_scene_ready = False
         self._slots: list[_LiberoSlot] = []
         self._slot_mutation_lock = threading.Lock()
         self._envs: list[Any] = []
@@ -728,6 +742,7 @@ class LiberoEnvCore:
         self.total_num_processes = total_processes
         self._core_form = core_form
         self._vector_initialized = False
+        self._vector_gpu_scene_ready = False
         self._slots = slots
         self._envs = envs
         self.closed = False
@@ -939,12 +954,44 @@ class LiberoEnvCore:
         for slot_index in slots:
             slot = self._require_slot(slot_index)
             reset_state_id = self._reset_state_id(slot, reset_spec)
-            obs, _info = slot.env.reset(
-                env_idx=np.array([0]),
-                reset_state_ids=np.array([reset_state_id]),
+            reservation = (
+                contextlib.nullcontext()
+                if slot.gpu_scene_ready
+                else reserve_gpu_memory(
+                    self.config.gpu_memory_reserve_mib,
+                    device=(
+                        None
+                        if os.environ.get("CUDA_VISIBLE_DEVICES")
+                        else slot.process_offset
+                    ),
+                )
             )
+            try:
+                with reservation:
+                    obs, _info = slot.env.reset(
+                        env_idx=np.array([0]),
+                        reset_state_ids=np.array([reset_state_id]),
+                    )
+            except GpuMemoryExhausted as exc:
+                raise RuntimeApiError(
+                    make_error(
+                        ErrorCode.RESOURCE_EXHAUSTED,
+                        f"GPU memory guard rejected libero.reset[slot={slot_index}]: "
+                        f"{exc}",
+                        resource="gpu_memory",
+                        reason="OOM",
+                        slot_index=slot_index,
+                        device=exc.device,
+                        requested_mib=exc.requested_mib,
+                        available_mib=exc.available_mib,
+                    )
+                ) from exc
             self._after_reset(slot_index, reset_state_id, reset_spec, obs)
-            observations.append(self._observation(slot_index, obs))
+            observation = self._observation(slot_index, obs)
+            # Commit the cold-to-warm transition last. Any failure in the
+            # reset or its bookkeeping must reserve again on retry.
+            slot.gpu_scene_ready = True
+            observations.append(observation)
         return observations
 
     def _reset_lockstep(
@@ -982,10 +1029,35 @@ class LiberoEnvCore:
             all_lanes = [slot.lane_index for slot in self._slots]
             lanes = all_lanes
             reset_state_ids = [requested.get(lane, filler) for lane in all_lanes]
-        obs, _info = env.reset(
-            env_idx=np.array(lanes),
-            reset_state_ids=np.array(reset_state_ids),
+        reservation = (
+            contextlib.nullcontext()
+            if self._vector_gpu_scene_ready
+            else reserve_gpu_memory(
+                self.config.gpu_memory_reserve_mib,
+                device=(
+                    None if os.environ.get("CUDA_VISIBLE_DEVICES") else self.seed_offset
+                ),
+            )
         )
+        try:
+            with reservation:
+                obs, _info = env.reset(
+                    env_idx=np.array(lanes),
+                    reset_state_ids=np.array(reset_state_ids),
+                )
+        except GpuMemoryExhausted as exc:
+            raise RuntimeApiError(
+                make_error(
+                    ErrorCode.RESOURCE_EXHAUSTED,
+                    f"GPU memory guard rejected libero.reset[vector]: {exc}",
+                    resource="gpu_memory",
+                    reason="OOM",
+                    slots=list(slots),
+                    device=exc.device,
+                    requested_mib=exc.requested_mib,
+                    available_mib=exc.available_mib,
+                )
+            ) from exc
         # Only set the flag **after success**: setting it on failure would
         # make a retry go through the subset-reset path -- exactly the path
         # that raises ``'NoneType' object is not subscriptable`` on an
@@ -998,6 +1070,9 @@ class LiberoEnvCore:
             index = lanes.index(slot.lane_index)
             self._after_reset(slot_index, int(reset_state_ids[index]), reset_spec, obs)
             observations.append(self._observation(slot_index, obs))
+        # As above, only the complete reset transaction makes the shared
+        # scene warm. A failed cold reset must reserve again on retry.
+        self._vector_gpu_scene_ready = True
         return observations
 
     def _after_reset(

--- a/rollout_runtime/config/presets/a100_libero.yaml
+++ b/rollout_runtime/config/presets/a100_libero.yaml
@@ -32,6 +32,7 @@ env_config:
   camera_depths: true
   return_all_frames: false
   libero_variant: standard
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/rollout_runtime/config/presets/a100_libero_pi05.yaml
+++ b/rollout_runtime/config/presets/a100_libero_pi05.yaml
@@ -47,6 +47,7 @@ env_config:
   # §2.5 的 256 KiB inline 阈值。需要逐帧时才打开（等价 legacy return_all_frames）。
   return_all_frames: false
   libero_variant: standard
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/rollout_runtime/config/presets/a100_libero_pi05_pro.yaml
+++ b/rollout_runtime/config/presets/a100_libero_pi05_pro.yaml
@@ -42,6 +42,7 @@ env_config:
   return_all_frames: true
   # 相对于 a100_libero_pi05.yaml 的实质改动：standard -> pro。
   libero_variant: pro
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/rollout_runtime/config/presets/a100_libero_pi05_pro_dynamic.yaml
+++ b/rollout_runtime/config/presets/a100_libero_pi05_pro_dynamic.yaml
@@ -48,6 +48,7 @@ env_config:
   action_model_type: openpi
   return_all_frames: true
   libero_variant: pro
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/rollout_runtime/config/presets/a100_libero_pi05_standard.yaml
+++ b/rollout_runtime/config/presets/a100_libero_pi05_standard.yaml
@@ -32,6 +32,7 @@ env_config:
   return_all_frames: true
   # 相对于 a100_libero_pi05_pro.yaml 的唯一改动：pro -> standard。
   libero_variant: standard
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/rollout_runtime/config/presets/zetta_libero_pi05.yaml
+++ b/rollout_runtime/config/presets/zetta_libero_pi05.yaml
@@ -60,6 +60,8 @@ env_config:
   # 且单个 payload 都在 256 KiB inline 阈值之内（oversize 计数不涨）。
   return_all_frames: true
   libero_variant: standard
+  # 只为首次成功的 scene reset 保留显存；warm reset 不重复扣账。
+  gpu_memory_reserve_mib: 800
 
 cluster:
   num_nodes: 1

--- a/tests/runtime/test_env_family_normalization.py
+++ b/tests/runtime/test_env_family_normalization.py
@@ -23,6 +23,7 @@ undeclared methods) and the capability table.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Any
 
 import numpy as np
@@ -86,6 +87,9 @@ def _build_core(env_config: dict[str, Any] | None = None, *, pool_size: int = 1)
         "camera_width": IMAGE_SIZE,
         "action_dim": ACTION_DIM,
         "chunk_size": 4,
+        # Unit tests use a simulator stub and must not depend on live host
+        # NVML state. GPU-guard tests opt back in explicitly below.
+        "gpu_memory_reserve_mib": 0,
         **(env_config or {}),
     }
     spec = EnvSpecMsg(
@@ -399,6 +403,108 @@ def test_reset_produces_the_five_key_schema(
     core.close()
 
 
+def test_per_slot_reset_reserves_gpu_memory_only_until_scene_is_ready(
+    stub_rlinf: type[_StubLiberoEnv], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cold resets reserve once per slot while warm resets skip the ledger."""
+    from rollout_runtime.backends import rlinf_env
+
+    core = _build_core({"gpu_memory_reserve_mib": 800}, pool_size=2)
+    reservations: list[tuple[int, int | None]] = []
+
+    @contextmanager
+    def record_reservation(requested_mib: int, *, device: int | None = None):
+        reservations.append((requested_mib, device))
+        yield
+
+    monkeypatch.setattr(rlinf_env, "reserve_gpu_memory", record_reservation)
+
+    core.reset([0], ResetSpec(task_id=0, seed=0))
+    core.reset([0], ResetSpec(task_id=0, seed=1))
+    core.reset([1], ResetSpec(task_id=0, seed=2))
+    core.reset([1], ResetSpec(task_id=0, seed=3))
+
+    assert [requested for requested, _device in reservations] == [800, 800]
+    assert [slot.gpu_scene_ready for slot in core._slots] == [True, True]  # noqa: SLF001
+    core.close()
+
+
+def test_failed_per_slot_cold_reset_reserves_again_on_retry(
+    stub_rlinf: type[_StubLiberoEnv], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed first reset must not make the slot look warm."""
+    from rollout_runtime.backends import rlinf_env
+
+    core = _build_core({"gpu_memory_reserve_mib": 800})
+    reservations = 0
+
+    @contextmanager
+    def record_reservation(requested_mib: int, *, device: int | None = None):
+        del requested_mib, device
+        nonlocal reservations
+        reservations += 1
+        yield
+
+    monkeypatch.setattr(rlinf_env, "reserve_gpu_memory", record_reservation)
+    env = core._slots[0].env  # noqa: SLF001
+    original_reset = env.reset
+    attempts = 0
+
+    def fail_once(*, env_idx: np.ndarray, reset_state_ids: np.ndarray):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("cold reset failed")
+        return original_reset(env_idx=env_idx, reset_state_ids=reset_state_ids)
+
+    monkeypatch.setattr(env, "reset", fail_once)
+    with pytest.raises(RuntimeError, match="cold reset failed"):
+        core.reset([0], ResetSpec(task_id=0, seed=0))
+    assert core._slots[0].gpu_scene_ready is False  # noqa: SLF001
+
+    core.reset([0], ResetSpec(task_id=0, seed=0))
+    assert reservations == 2
+    assert core._slots[0].gpu_scene_ready is True  # noqa: SLF001
+    core.close()
+
+
+def test_gpu_guard_rejection_is_resource_exhausted_and_slot_stays_cold(
+    stub_rlinf: type[_StubLiberoEnv], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Admission rejection is retryable and cannot consume the cold marker."""
+    from rollout_runtime.backends import rlinf_env
+    from zetta.utils.gpu_memory_guard import GpuMemoryExhausted
+
+    core = _build_core({"gpu_memory_reserve_mib": 800})
+    attempts = 0
+
+    @contextmanager
+    def reject_once(requested_mib: int, *, device: int | None = None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise GpuMemoryExhausted(
+                device=0,
+                requested_mib=requested_mib,
+                available_mib=128,
+            )
+        del device
+        yield
+
+    monkeypatch.setattr(rlinf_env, "reserve_gpu_memory", reject_once)
+    with pytest.raises(RuntimeApiError) as excinfo:
+        core.reset([0], ResetSpec(task_id=0, seed=0))
+    assert excinfo.value.info.code is ErrorCode.RESOURCE_EXHAUSTED
+    assert excinfo.value.info.detail["resource"] == "gpu_memory"
+    assert excinfo.value.info.detail["slot_index"] == 0
+    assert core._slots[0].gpu_scene_ready is False  # noqa: SLF001
+
+    core.reset([0], ResetSpec(task_id=0, seed=0))
+    assert attempts == 2
+    assert core._slots[0].gpu_scene_ready is True  # noqa: SLF001
+    core.close()
+
+
 def test_observe_before_reset_is_rejected(
     stub_rlinf: type[_StubLiberoEnv],
 ) -> None:
@@ -701,6 +807,7 @@ def test_env_config_aliases_and_unknown_keys() -> None:
     assert config.task_suite_name == "libero_goal"
     assert config.max_episode_steps == 300
     assert (config.camera_height, config.camera_width) == (128, 64)
+    assert LiberoEnvConfig.from_mapping({}).gpu_memory_reserve_mib == 800
 
     with pytest.raises(RuntimeApiError) as excinfo:
         LiberoEnvConfig.from_mapping({"image_hieght": 256})
@@ -789,6 +896,49 @@ def test_libero_accepts_the_core_form_key_and_builds_one_vector_env(
     assert core._envs[0].num_envs == 3
     assert [slot.lane_index for slot in core._slots] == [0, 1, 2]
     assert core._envs[0].is_start is False
+    core.close()
+
+
+def test_vector_reset_reserves_once_and_failed_cold_reset_retries(
+    stub_rlinf: type[_StubLiberoEnv], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shared vector scene becomes warm only after reset succeeds."""
+    from rollout_runtime.backends import rlinf_env
+
+    core = _build_core(
+        {"core_form": LOCKSTEP_VECTOR_FORM, "gpu_memory_reserve_mib": 800},
+        pool_size=2,
+    )
+    reservations = 0
+
+    @contextmanager
+    def record_reservation(requested_mib: int, *, device: int | None = None):
+        del requested_mib, device
+        nonlocal reservations
+        reservations += 1
+        yield
+
+    monkeypatch.setattr(rlinf_env, "reserve_gpu_memory", record_reservation)
+    env = core._envs[0]  # noqa: SLF001
+    original_reset = env.reset
+    attempts = 0
+
+    def fail_once(*, env_idx: np.ndarray, reset_state_ids: np.ndarray):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("vector cold reset failed")
+        return original_reset(env_idx=env_idx, reset_state_ids=reset_state_ids)
+
+    monkeypatch.setattr(env, "reset", fail_once)
+    with pytest.raises(RuntimeError, match="vector cold reset failed"):
+        core.reset([0], ResetSpec(task_id=0, seed=0))
+    assert core._vector_gpu_scene_ready is False  # noqa: SLF001
+
+    core.reset([0], ResetSpec(task_id=0, seed=0))
+    core.reset([1], ResetSpec(task_id=0, seed=1))
+    assert reservations == 2
+    assert core._vector_gpu_scene_ready is True  # noqa: SLF001
     core.close()
 
 

--- a/tests/test_gpu_memory_guard.py
+++ b/tests/test_gpu_memory_guard.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Zetta Contributors
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from zetta.utils import gpu_memory_guard
+
+
+class _FakeNvml:
+    def __init__(self, free_mib: int) -> None:
+        self.free_bytes = free_mib * 1024 * 1024
+
+    def nvmlDeviceGetHandleByIndex(self, index: int) -> int:
+        return index
+
+    def nvmlDeviceGetMemoryInfo(self, handle: int) -> SimpleNamespace:
+        del handle
+        return SimpleNamespace(free=self.free_bytes)
+
+
+@pytest.fixture(autouse=True)
+def _clear_reservations() -> None:
+    gpu_memory_guard._RESERVED_MIB.clear()  # noqa: SLF001
+    yield
+    gpu_memory_guard._RESERVED_MIB.clear()  # noqa: SLF001
+
+
+def test_nested_reservations_account_for_inflight_allocations(monkeypatch) -> None:
+    """The second caller sees the first caller's in-flight reservation."""
+    monkeypatch.setattr(gpu_memory_guard, "_nvml", lambda: _FakeNvml(3000))
+
+    with gpu_memory_guard.reserve_gpu_memory(1000, device=0, safety_margin_mib=500):
+        assert gpu_memory_guard.reservation_snapshot() == {0: 1000}
+        with pytest.raises(gpu_memory_guard.GpuMemoryExhausted) as excinfo:
+            with gpu_memory_guard.reserve_gpu_memory(
+                2000, device=0, safety_margin_mib=500
+            ):
+                pass
+        assert excinfo.value.available_mib == 2000
+
+    assert gpu_memory_guard.reservation_snapshot() == {}
+
+
+def test_reservation_is_released_when_native_call_fails(monkeypatch) -> None:
+    """Exceptions inside the guarded operation cannot leak ledger capacity."""
+    monkeypatch.setattr(gpu_memory_guard, "_nvml", lambda: _FakeNvml(4096))
+
+    with pytest.raises(RuntimeError, match="native failure"):
+        with gpu_memory_guard.reserve_gpu_memory(800, device=1, safety_margin_mib=512):
+            assert gpu_memory_guard.reservation_snapshot() == {1: 800}
+            raise RuntimeError("native failure")
+
+    assert gpu_memory_guard.reservation_snapshot() == {}

--- a/zetta/utils/gpu_memory_guard.py
+++ b/zetta/utils/gpu_memory_guard.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 Zetta Contributors
+"""Fail-fast GPU memory reservations for native environment construction.
+
+Ray's fractional GPU resource is only a scheduler quota. MuJoCo/EGL
+constructors can still block inside a native call when the physical card is
+nearly full. This module provides a small process-local reservation ledger and
+an NVML check immediately before those calls. NVML is optional: when it is
+unavailable the guard becomes a no-op unless strict mode is requested with
+``ZETTA_GPU_MEMORY_GUARD_STRICT=1``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class GpuMemoryExhausted(RuntimeError):
+    """The requested native allocation should be rejected before blocking."""
+
+    def __init__(self, *, device: int, requested_mib: int, available_mib: int) -> None:
+        self.device = int(device)
+        self.requested_mib = int(requested_mib)
+        self.available_mib = int(available_mib)
+        super().__init__(
+            f"GPU {self.device} has only {self.available_mib} MiB effective free; "
+            f"reservation requires {self.requested_mib} MiB"
+        )
+
+
+_LOCK = threading.RLock()
+_RESERVED_MIB: dict[int, int] = {}
+
+
+def _strict() -> bool:
+    return os.environ.get("ZETTA_GPU_MEMORY_GUARD_STRICT", "0") == "1"
+
+
+def _nvml():
+    try:
+        import pynvml  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001 - optional dependency
+        return None
+    try:
+        pynvml.nvmlInit()
+    except Exception:  # noqa: BLE001 - driver may be unavailable
+        return None
+    return pynvml
+
+
+def _device_index(device: int | None) -> int:
+    if device is not None:
+        return max(0, int(device))
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",", 1)[0].strip()
+    with contextlib.suppress(ValueError):
+        if raw:
+            return max(0, int(raw))
+    return 0
+
+
+@contextmanager
+def reserve_gpu_memory(
+    requested_mib: int | float = 0,
+    *,
+    device: int | None = None,
+    safety_margin_mib: int | float = 1024,
+) -> Iterator[None]:
+    """Reserve memory and fail fast if effective NVML free memory is low.
+
+    ``requested_mib <= 0`` disables the check. The reservation is released in
+    ``finally`` even when native construction raises.
+    """
+
+    requested = max(0, int(float(requested_mib)))
+    if requested <= 0:
+        yield
+        return
+    index = _device_index(device)
+    nvml = _nvml()
+    if nvml is None:
+        if _strict():
+            raise GpuMemoryExhausted(
+                device=index, requested_mib=requested, available_mib=0
+            )
+        yield
+        return
+
+    nvml_error = False
+    with _LOCK:
+        try:
+            handle = nvml.nvmlDeviceGetHandleByIndex(index)
+            info = nvml.nvmlDeviceGetMemoryInfo(handle)
+            free_mib = int(info.free // (1024 * 1024))
+        except Exception:  # noqa: BLE001 - NVML failures follow strict-mode policy
+            nvml_error = True
+            free_mib = 0
+        if not nvml_error:
+            reserved = _RESERVED_MIB.get(index, 0)
+            effective = free_mib - reserved
+            margin = max(0, int(float(safety_margin_mib)))
+            if effective < requested + margin:
+                raise GpuMemoryExhausted(
+                    device=index,
+                    requested_mib=requested,
+                    available_mib=effective,
+                )
+            _RESERVED_MIB[index] = reserved + requested
+    if nvml_error:
+        if _strict():
+            raise GpuMemoryExhausted(
+                device=index, requested_mib=requested, available_mib=0
+            )
+        yield
+        return
+    try:
+        yield
+    finally:
+        with _LOCK:
+            remaining = _RESERVED_MIB.get(index, 0) - requested
+            if remaining > 0:
+                _RESERVED_MIB[index] = remaining
+            else:
+                _RESERVED_MIB.pop(index, None)
+
+
+def reservation_snapshot() -> dict[int, int]:
+    """Return a copy of the process-local reservation ledger."""
+
+    with _LOCK:
+        return dict(_RESERVED_MIB)
+
+
+__all__ = ["GpuMemoryExhausted", "reservation_snapshot", "reserve_gpu_memory"]


### PR DESCRIPTION
## Summary

Fixes #20 by reserving GPU memory only during the first successful LIBERO scene reset. Warm episode-boundary resets now reuse the initialized EGL/MuJoCo scene without debiting the reservation ledger again.

## Root cause

Concurrent warm resets each reserved approximately 800 MiB even though they did not create new GPU scenes. These temporary ledger entries accumulated and caused false `RESOURCE_EXHAUSTED` errors while NVML still reported sufficient free memory.

## Changes

- Add an NVML-backed, process-local GPU memory guard.
- Track scene readiness per slot and per lockstep vector pool.
- Skip GPU reservation for warm resets.
- Keep failed cold resets cold so retries still reserve memory.
- Map admission failures to structured `RESOURCE_EXHAUSTED` errors.
- Add the 800 MiB reservation setting to LIBERO presets.
- Add regression coverage for reservation accounting and reset lifecycle behavior.

## Validation

- Focused/runtime tests: `109 passed, 6 skipped`
- Preset checks: `2 passed`
- Ruff, compilation, and whitespace checks passed.

### 2× RTX 4090 hardware stress test

| Aggregate level | Slots per GPU | Warm rounds | Warm resets | Failures | Warm reservation calls |
|---|---:|---:|---:|---:|---:|
| 48 | 24 | 5 | 240 | 0 | 0 |
| 56 | 28 | 5 | 280 | 0 | 0 |

Additional results:

- 56 cold resets produced exactly 56 reservation calls.
- 520 warm resets completed without `RESOURCE_EXHAUSTED`.
- No leaked reservation entries or test processes remained.
- GPU memory returned to the pre-test background level.
- Under the same NVML conditions, the old behavior would reject 3 resets per GPU at level 48 and 7 per GPU at level 56.

## Scope

The hardware test exercised real LIBERO-Pro, MuJoCo, and EGL scene creation/reset/close paths. It intentionally excluded Pi0.5 inference to isolate the reset and GPU-admission behavior.

Fixes #20
